### PR TITLE
Adds Blogging Software and Forum Software to the lists

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,8 +25,8 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Humanize](#humanize)
 - [Static site generators](#static-site-generators)
 - [Content management systems](#content-management-systems)
-- [Forum Software](#forum-software)
-- [Blogging Software](#blogging-software)
+- [Forum](#forum)
+- [Blogging](#blogging)
 - [Debugging](#debugging)
 - [Database](#database)
 - [Testing](#testing)
@@ -174,11 +174,11 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [KeystoneJS](http://keystonejs.com) - CMS and web application platform built on Express and MongoDB.
 - [Calipso](http://calip.so) - A simple content management system, built along similar themes to Drupal and Wordpress, that is designed to be fast, flexible and simple.
 
-### Forum Software
+### Forum
 
 - [nodeBB](https://nodebb.org/) - A better forum platform for the modern web. The next generation forum software that's free and easy to use.
 
-### Blogging Software
+### Blogging
 
 - [ghost](https://ghost.org/) - Ghost is a simple, powerful publishing platform that allows you to share your story with the world. 
 - [Hexo](http://hexo.io/) - A fast, simple and powerful blogging framework powered by node.js.


### PR DESCRIPTION
Nodejs has some great web software available which I have added to this list.
- I am a fan of the [nodeBB Forum Software](https://nodebb.org/) because the 'BB' forums have been around for a long time as with phpBB, however this is a natural progression toward a more cleaner interface/less heavier or clunky framework. I hope that eventually this will replace BB forums everywhere.
- I added some Blogging Software to the list as it seem to not be included. [Ghost](https://ghost.org/) seems to be very popular and [Hexo](http://hexo.io/) is a minimalistic blogging software. Ghost is based on SQLlite while Hexo is a static file blogging system.
