### PR TITLE
Add Bookshelf to ODM / ORM

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -259,6 +259,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
   - [MySQL](https://github.com/felixge/node-mysql) - A pure Node.js JavaScript Client implementing the MySQL protocol.
   - [Redis](https://github.com/mranney/node_redis) - Redis client for Node.js.
 - ODM / ORM
+  - [Bookshelf](http://bookshelfjs.org/) - A Node.js ORM for PostgreSQL, MySQL and SQLite3 in the style of Backbone.js.
   - [Mongoose](http://mongoosejs.com/) - Elegant MongoDB object modeling for Node.js.
   - [Sequelize](https://github.com/sequelize/sequelize) - Multi-dialect ORM. Supports SQLite, MySQL, PostgreSQL.
 


### PR DESCRIPTION
This adds [Bookshelf](https://github.com/tgriesser/bookshelf), a valid alternative to [Sequelize](https://github.com/sequelize/sequelize).
