### PR TITLE
Add Hogan.js to templates

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -110,7 +110,8 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 ### Templating
 
-- [handlebars.js](https://github.com/wycats/handlebars.js/) - Provides the power necessary to let you build semantic templates effectively with no frustration.
+- [handlebars.js](https://github.com/wycats/handlebars.js/) - A superset of Mustache templates which adds powerful features like helpers and more advanced blocks.
+- [hogan.js](http://twitter.github.io/hogan.js/) - Twitter's small, fast, phase-separated compiler for Mustache templates.
 - [Jade](https://github.com/visionmedia/jade) - High performance template engine heavily influenced by Haml.
 - [nunjucks](https://github.com/mozilla/nunjucks) - A powerful templating engine with inheritance, asynchronous control, and more (jinja2 inspired).
 


### PR DESCRIPTION
Because you can't have Handlebars without it's Mustache roots, and [Hogan](http://twitter.github.io/hogan.js/) is the de-facto Mustache compiler in JS.

Also changed the Handlebars description to be a description rather than a pitch.
