### PR TITLE
Add slimver

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -315,6 +315,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [multiline](https://github.com/sindresorhus/multiline) - Multiline strings in JavaScript.
 - [opn](https://github.com/sindresorhus/opn) - Opens stuff like websites, files, executables.
 - [semver](https://github.com/isaacs/node-semver) - [semver](http://semver.org) parser.
+- [slimver](https://github.com/DamonOehlman/slimver) - [slimver](http://slimver.org/) parser.
 - [cheerio](https://github.com/cheeriojs/cheerio) - Fast, flexible, and lean implementation of core jQuery designed specifically for the server.
 - [browserify](https://github.com/substack/node-browserify) - Browser-side require() the Node.js way.
 - [Faker.js](https://github.com/Marak/Faker.js) - Generate massive amounts of fake data.


### PR DESCRIPTION
[slimver](http://slimver.org/) is a simplified and more strict variant of [semver](http://semver.org).

It provides the compatibility (`^`) operator (which has consistent semantics), and allow version locking (like `n.n.x`). [Motivation](https://github.com/dominictarr/semver-ftw/issues/2) behind this project.
