### PR TITLE
Add normit package.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [David](https://github.com/alanshaw/david) - Tells you when your package npm dependencies are out of date.
 - [vtop](https://github.com/MrRio/vtop) - More better top, with nice charts.
 - [tmpin](https://github.com/sindresorhus/tmpin) - Adds stdin support to any CLI app that accepts file input.
+- [normit](https://github.com/pawurb/normit) - Google Translate with speech synthesis in your terminal.
 
 
 ### HTTP
@@ -119,7 +120,6 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [progress](https://github.com/visionmedia/node-progress) - Flexible ascii progress bar.
 - [log-symbols](https://github.com/sindresorhus/log-symbols) - Colored symbols for various log levels.
 - [columnify](https://github.com/timoxley/columnify) - Create text-based columns suitable for console output. Supports cell wrapping.
-- [normit](https://github.com/pawurb/normit) - Google Translate with speech synthesis in your terminal.
 
 
 ### Build tools


### PR DESCRIPTION
I would like to recommend [normit](https://github.com/pawurb/normit) npm package. It is a node.js port of a [termit](https://github.com/pawurb/termit) RubyGem which was featured in Ruby Weekly 168 and on the main page of HN.
