### PR TITLE
Add JugglingDB to ODM / ORM

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -292,6 +292,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
   - [Redis](https://github.com/mranney/node_redis) - Redis client for Node.js.
 - ODM / ORM
   - [Bookshelf](http://bookshelfjs.org/) - A Node.js ORM for PostgreSQL, MySQL and SQLite3 in the style of Backbone.js.
+  - [JugglingDB](https://github.com/1602/jugglingdb) - Multi-database ORM: Redis, MongoDB, MySQL, SQLite, PostgreSQL, Neo4j, memory... Many databases, common API.
   - [Mongoose](http://mongoosejs.com/) - Elegant MongoDB object modeling for Node.js.
   - [Sequelize](https://github.com/sequelize/sequelize) - Multi-dialect ORM. Supports SQLite, MySQL, PostgreSQL.
 - Query builder


### PR DESCRIPTION
This adds [JugglingDB](https://github.com/1602/jugglingdb), an ORM with many [adapters](https://github.com/1602/jugglingdb#jugglingdb-adapters).
