### PR TITLE
Added oauth-signature-js to HTTP

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [got](https://github.com/sindresorhus/got) - A nicer interface to the built-in `http` module.
 - [superagent](https://github.com/visionmedia/superagent) - A small progressive HTTP request library.
 - [hyperquest](https://github.com/substack/hyperquest) - Streaming HTTP requests.
+- [oauth-signature-js](https://github.com/bettiolo/oauth-signature-js) - OAuth 1.0a signature generator
 
 
 ### Debugging / Profiling


### PR DESCRIPTION
[oauth-signature-js](https://github.com/bettiolo/oauth-signature-js) - OAuth 1.0a signature generator
It should be added as there is no library to generate oauth signatures in the list, the one I built is following the spec and is extensively tested
