### PR TITLE
Add canvas to Miscellaneous

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -367,6 +367,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [BitcoinJS](http://bitcoinjs.org/) - The clean, readable, proven library for Bitcoin JavaScript development.
 - [Bottleneck](https://github.com/SGrondin/bottleneck) - A powerful rate limiter that makes throttling easy.
 - [PDFKit](http://pdfkit.org/) - A JavaScript PDF generation library.
+- [canvas](https://github.com/automattic/node-canvas) - A Cairo backed Canvas implementation.
 
 
 ## Resources


### PR DESCRIPTION
This adds [node-canvas](https://github.com/automattic/node-canvas), a canvas implementation with extended APIs to support node features like `Streams`, `Buffers`, etc.
