### PR TITLE
Add spdy to HTTP

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [got](https://github.com/sindresorhus/got) - A nicer interface to the built-in `http` module.
 - [superagent](https://github.com/visionmedia/superagent) - A small progressive HTTP request library.
 - [hyperquest](https://github.com/substack/hyperquest) - Streaming HTTP requests.
+- [spdy](https://github.com/indutny/node-spdy) - Creates SPDY servers with the same API as the built-in `https` module.
 
 
 ### Debugging / Profiling


### PR DESCRIPTION
This adds [spdy](https://github.com/indutny/node-spdy) to create SPDY servers.
