### PR TITLE
Add jsfmt to Command-line apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [vtop](https://github.com/MrRio/vtop) - More better top, with nice charts.
 - [tmpin](https://github.com/sindresorhus/tmpin) - Adds stdin support to any CLI app that accepts file input.
 - [normit](https://github.com/pawurb/normit) - Google Translate with speech synthesis in your terminal.
+- [jsfmt](http://rdio.github.io/jsfmt/) - For formatting, searching, and rewriting JavaScript. Analogous to [`gofmt`](http://golang.org/cmd/gofmt/).
 
 
 ### HTTP


### PR DESCRIPTION
This adds [jsfmt](http://rdio.github.io/jsfmt/), `gofmt` for JavaScript.
