### PR TITLE
Update readme.md: parser5 -> parse5

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -261,7 +261,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [JSONStream](https://github.com/dominictarr/JSONStream) - Streaming JSON.parse and stringify.
 - [csv-parser](https://github.com/mafintosh/csv-parser) - Streaming CSV parser that aims to be faster than everyone else.
 - [excel-stream](https://github.com/dominictarr/excel-stream) - Streaming Excel spreadsheet to JSON parser.
-- [parser5](https://github.com/inikulin/parse5) - Fast full-featured spec compliant HTML parser.
+- [parse5](https://github.com/inikulin/parse5) - Fast full-featured spec compliant HTML parser.
 - [htmlparser2](https://github.com/fb55/htmlparser2/) - Forgiving HTML/XML parser.
 - [PostCSS](https://github.com/postcss/postcss) - Framework for CSS postprocessors, to modify CSS.
 


### PR DESCRIPTION
Hi, thanks for adding parse5 to your awesome list. But it's 'parse5', not 'parser5' =)
