### PR TITLE
Add chai to Testing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -338,6 +338,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Mocha](http://visionmedia.github.io/mocha/) - A feature-rich test framework making asynchronous testing simple and fun.
 - [loadtest](https://github.com/alexfernandez/loadtest) - Run load tests for your web application, with an API for automation.
 - [istanbul](https://github.com/gotwarlost/istanbul) - A code coverage tool that computes statement, line, function and branch coverage with module loader hooks to transparently add coverage when running tests.
+- [chai](http://chaijs.com/) - A framework agnostic BDD/TDD assertion library.
 
 
 ### Benchmarking


### PR DESCRIPTION
This adds [chai](https://github.com/chaijs/chai), a popular BDD/TDD assertion library.

I also found the [vstream](https://github.com/joyent/node-vstream) module interesting. It is useful to debug a pipeline of streams. Does it make sense to add it or is it better to wait until it is more mature?
