### PR TITLE
Documentation: add mdextract

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -165,6 +165,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [JSDoc](http://usejsdoc.org) - API documentation generator similar to JavaDoc or PHPDoc.
 - [dox](https://github.com/visionmedia/dox) - JavaScript documentation generator using Markdown and JSDoc.
 - [jsdox](https://github.com/sutoiku/jsdox) - JSDoc3 to Markdown documentation generator.
+- [mdextract](https://github.com/rstacruz/mdextract) - Extracts code comments into Markdown documents.
 
 
 ### Filesystem


### PR DESCRIPTION
I have a modest little project called [mdextract](https://github.com/rstacruz/mdextract), which simply gets inline `/** comments */` and extracts them into markdown documents. Check it out!
