### PR TITLE
Add allong.es to functional programming category

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [mori](http://swannodette.github.io/mori/) - A library for using ClojureScript's persistent data structures and supporting API from the comfort of vanilla JavaScript.
 - [Folktale](http://folktale.github.io) - A suite of libraries for generic functional programming in JavaScript that allows you to write elegant modular applications with fewer bugs, and more reuse.
 - [immutable](https://github.com/facebook/immutable-js) - Immutable data collections.
+- [allong.es](http://allong.es/) - Combinators and function decorators.
 
 
 ### HTTP


### PR DESCRIPTION
Url to the package: https://www.npmjs.org/package/allong.es

allong.es is a library done by the guy who wrote one of the best books about functional programming in JS: JavaScript Allonge (https://leanpub.com/javascript-allonge) - the lib is complementary to the book (it's the implementation of what the book tells about).

From the lib's readme:

> The allong.es library is a collection of functions designed to facilitate writing JavaScript and/or CoffeeScript with functions as first-class values. The emphasis in allong.es is on composing and decomposing functions using combinators and decorators. allong.es is designed to complement libraries like Underscore, not compete with them.
