### PR TITLE
Adding suspend, a generator-based control flow library.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -215,6 +215,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 	- [async](https://github.com/caolan/async) - Provides straight-forward, powerful functions for working with asynchronousity.
 - Generators
 	- [co](https://github.com/visionmedia/co) - The ultimate generator based flow-control goodness.
+	- [suspend](https://github.com/jmar777/suspend) - Generator-based control flow that plays nice with callbacks, promises, and thunks.
 - Promises
 	- [native-promise-only](https://github.com/getify/native-promise-only) - A polyfill for native ES6 Promises.
 	- [Bluebird](https://github.com/petkaantonov/bluebird) - A fully featured promise library with focus on innovative features and performance.


### PR DESCRIPTION
Suspend is a generator-based control-flow for Node that is designed to play nice with callbacks, promises, and thunks.  It's available on npm as [suspend](https://www.npmjs.org/package/suspend), and the code is available on [GitHub](https://github.com/jmar777/suspend).
