### PR TITLE
Added Apper in Web Frameworks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 - [Koa](http://koajs.com) - A new web framework designed by the team behind Express, which aims to be a smaller, more expressive, and more robust foundation for web applications and APIs.
 - [Express](http://expressjs.com) - A minimal and flexible web application framework, providing a robust set of features for building single and multi-page, and hybrid web applications.
+- [Apper](https://github.com/asyncanup/apper) - Plug and play, restful, real-time application framework for single page apps.
 - [Hapi](http://hapijs.com) - A rich framework for building applications and services.
 - [LoopBack](http://loopback.io) - Powerful framework for creating REST APIs and easily connecting to backend data sources.
 - [Meteor](https://www.meteor.com) - An ultra-simple, database-everywhere, data-on-the-wire, pure-Javascript web framework.


### PR DESCRIPTION
Apper is built on top of Express (hence the position) to provide the following that Express misses out on (by design):
- Much needed structure to server-side code with strong conventions
- Reliable directory hierarchy for code based on REST end-points
- Design for real-time right off the bat
- Transparent minification & bundling for single page apps
