### PR TITLE
Added Iridium

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -366,6 +366,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 	- [Mongoose](http://mongoosejs.com) - Elegant MongoDB object modeling.
 	- [Sequelize](https://github.com/sequelize/sequelize) - Multi-dialect ORM. Supports PostgreSQL, SQLite, MySQL.
     - [Waterline](https://github.com/balderdashy/waterline) - Datastore-agnostic tool that dramatically simplifies interaction with one or more databases.
+	- [Iridium](https://github.com/SierraSoftworks/Iridium) - A high performance MongoDB ORM with support for promises, distributed caching, preprocessing, validation and plugins.
 - Query builder
 	- [Knex](http://knexjs.org) - A query builder for PostgreSQL, MySQL and SQLite3, designed to be flexible, portable, and fun to use.
 


### PR DESCRIPTION
Iridium is a MongoDB ORM, currently in its 3rd major release version. It has been extensively tested and used in a number of live deployments.
