### PR TITLE
Add after-all-results to Control flow section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -213,6 +213,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - Callbacks
 	- [each-async](https://github.com/sindresorhus/each-async) - Async concurrent iterator like forEach.
 	- [async](https://github.com/caolan/async) - Provides straight-forward, powerful functions for working with asynchronousity.
+	- [after-all-results](https://github.com/watson/after-all-results) - Bundle results of async functions calls into one callback with all the results.
 - Generators
 	- [co](https://github.com/visionmedia/co) - The ultimate generator based flow-control goodness.
 - Promises


### PR DESCRIPTION
The module `after-all-results` is an extremely lightweight way of performing a series of async function calls and have it call a callback function once they have all finished.

The callback will be called with an array of the results from the async function calls.

The focus of the module is to do this with as little a coding overhead as possible.
