### PR TITLE
Add stackman in Debugging / Profiling section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [spy-js](https://github.com/spy-js/spy-js#installation) - Tracing tool for JavaScript, featuring configurable event capturing, searchable call stack, code coverage, recorded object values inspection, multi process and node cluster tracing support.
 - [njsTrace](https://github.com/valyouw/njstrace) - Instrument and trace you code, see all function calls, arguments, return values, as well as the time spent in each function.
 - [vstream](https://github.com/joyent/node-vstream) - Instrumentable streams mix-ins to inspect a pipeline of streams.
+- [stackman](https://github.com/watson/stackman) - Enhance an error stacktrace with code excerpts and other goodies.
 
 
 ### Logging


### PR DESCRIPTION
When writing custom error loggers, Stackman gives you easy access to the V8 internals of the Error object. Besides the standard functions on a V8 callsite object, with Stackman you get a lot of extra features: For instance access to the actual source code and surrounding lines for where the error occurred, you get to know if it happened inside a 3rd party module, in Node.js or in your own code. 
