### PR TITLE
Add OpenRecord to ODM/ORMs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -375,6 +375,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 	- [Mongoose](http://mongoosejs.com) - Elegant MongoDB object modeling.
 	- [Sequelize](https://github.com/sequelize/sequelize) - Multi-dialect ORM. Supports PostgreSQL, SQLite, MySQL.
     - [Waterline](https://github.com/balderdashy/waterline) - Datastore-agnostic tool that dramatically simplifies interaction with one or more databases.
+    - [OpenRecord](https://github.com/PhilWaldmann/openrecord) - ORM for PostgreSQL, MySQL, SQLite3 and RESTful datastores. Similar to ActiveRecord.
 - Query builder
 	- [Knex](http://knexjs.org) - A query builder for PostgreSQL, MySQL and SQLite3, designed to be flexible, portable, and fun to use.
 


### PR DESCRIPTION
OpenRecord is similar to ActiveRecord. It currently supports PostgreSQL, MySQL, SQLite3 as well as RESTful datastores.
