### PR TITLE
add Channels to Control Flows, add js-csp

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -230,7 +230,8 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 	- [Q](https://github.com/kriskowal/q) - A tool for making and composing asynchronous promises.
 - Streams
 	- [Highland.js](http://highlandjs.org) - Manages synchronous and asynchronous code easily, using nothing more than standard JavaScript and Node-like Streams.
-
+- Channels
+	- [js-csp](https://github.com/jlongster/js-csp) - Communicating sequential processes for Javascript (like Clojurescript core.async, or Go). 
 
 ### Streams
 


### PR DESCRIPTION
js-csp adds CSP (Communicating Sequential Processes) - Go- and Clojurescript-like Channels - to JS. It's an alternative and graceful way of dealing with asynchronous control flow.

Read more from the module author at http://jlongster.com/Taming-the-Asynchronous-Beast-with-CSP-in-JavaScript
