### PR TITLE
Add object-stream-map in Streams section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -255,6 +255,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [multistream](https://github.com/feross/multistream) - Combine multiple streams into a single stream.
 - [graphicsmagick-stream](https://github.com/e-conomic/graphicsmagick-stream/) - Fast convertion/scaling of images using a pool of long lived graphicsmagick processes.
 - [readable-stream](https://github.com/isaacs/readable-stream) - Mirror of Streams2 and Streams3 implementations in core.
+- [object-stream-map](https://github.com/watson/object-stream-map) - Perform a map on a stream of objects.
 
 
 ### Real-time


### PR DESCRIPTION
https://github.com/watson/object-stream-map

When working with object streams, for instance MongoDB cursors, I've had situations where I just need a specific property on each object in the stream. This module provides a simple one-liner way of reducing each object in the stream to the named object property.
