### PR TITLE
Adding s3-upload-stream

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -255,6 +255,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [multistream](https://github.com/feross/multistream) - Combine multiple streams into a single stream.
 - [graphicsmagick-stream](https://github.com/e-conomic/graphicsmagick-stream/) - Fast convertion/scaling of images using a pool of long lived graphicsmagick processes.
 - [readable-stream](https://github.com/isaacs/readable-stream) - Mirror of Streams2 and Streams3 implementations in core.
+- [s3-upload-stream](https://github.com/nathanpeck/s3-upload-stream) - Upload a stream to an Amazon S3 bucket using multipart upload.
 
 
 ### Real-time


### PR DESCRIPTION
[s3-upload-stream](https://github.com/nathanpeck/s3-upload-stream) solves the problem of uploading streams of unknown length to Amazon S3. It makes streaming data to S3 as easy as calling .pipe() on a data stream.

s3-upload-stream can be used to create efficient servers that accept incoming data streams, process the data on the fly, and then stream the processed data to an S3 bucket. Examples include bulk data processing, video encoding, text compression, etc.
