### PR TITLE
Add wooorm/franc to Natural Language Processing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -451,6 +451,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 - [natural](https://github.com/NaturalNode/natural) - A general natural language facility.
 - [retext](https://github.com/wooorm/retext) - An extensible natural language system.
+- [franc](https://github.com/wooorm/franc) - Detect the language of text.
 - [leven](https://github.com/sindresorhus/leven) - Measure the difference between two strings using the Levenshtein distance algorithm.
 
 


### PR DESCRIPTION
This addition adds [franc](http://github.com/wooorm/franc), a library to detect which natural language (out of 160+ languages) is used in a given string, to Natural Language Processing.
