### PR TITLE
Add swig as template engine

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -203,6 +203,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [hogan.js](http://twitter.github.io/hogan.js/) - Twitter's small, fast, phase-separated compiler for Mustache templates.
 - [Jade](https://github.com/visionmedia/jade) - High performance template engine heavily influenced by Haml.
 - [nunjucks](https://github.com/mozilla/nunjucks) - A powerful templating engine with inheritance, asynchronous control, and more (jinja2 inspired).
+- [swig](http://paularmstrong.github.io/swig/) - A simple, powerful, and extendable JavaScript Template Engine.
 
 
 ### Documentation


### PR DESCRIPTION
Hello.

Another unlisted template engine, which is really good if you come from Symfony : http://paularmstrong.github.io/swig/

Thanks
