### PR TITLE
Add Bitcore to Mad science

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [peerwiki](https://github.com/mafintosh/peerwiki) - All of Wikipedia on BitTorrent.
 - [peercast](https://github.com/mafintosh/peercast) - Stream a torrent video to Chromecast.
 - [BitcoinJS](http://bitcoinjs.org) - Clean, readable, proven Bitcoin library.
+- [Bitcore](http://bitcore.io/) - A pure and powerful Bitcoin library.
 - [js-git](https://github.com/creationix/js-git) - JavaScript implementation of Git.
 - [NodeOS](http://node-os.com) - The first operating system powered by npm.
 - [PDFKit](http://pdfkit.org) - PDF generation library.


### PR DESCRIPTION
This adds [Bitcore](http://bitcore.io/), a library with bitcoin-related functions, and a good alternative for [BitcoinJS](https://github.com/bitcoinjs/bitcoinjs-lib).
