### PR TITLE
Add Grant to the Authentication section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -451,6 +451,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 ### Authentication
 
+- [Grant](https://github.com/simov/grant) - OAuth middleware for Express and Koa.
 - [Passport](http://passportjs.org) - Simple, unobtrusive authentication.
 - [everyauth](https://github.com/bnoguchi/everyauth) - Authentication and authorization (password, facebook, & more) for your Connect and Express apps.
 - [passwordless](https://passwordless.net) - Token-based authentication middleware for Express allowing authentication without passwords.


### PR DESCRIPTION
OAuth middleware for Express and Koa - the simplest way to deal with OAuth in the NodeJS world. You can take a look at the code and the documentation https://github.com/simov/grant and the showcase https://grant-oauth.herokuapp.com/

Currently supported providers **84** with Hapi support underway.