### PR TITLE
Add rest.js to http section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -117,6 +117,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [got](https://github.com/sindresorhus/got) / [sent](https://github.com/floatdrop/sent) - A nicer interface to the built-in `http` module.
 - [superagent](https://github.com/visionmedia/superagent) - A small progressive HTTP request library.
 - [axios](https://github.com/mzabriskie/axios) - Promise based HTTP client (works in the browser too).
+- [rest](https://github.com/cujojs/rest) - Modular promise-based HTTP client, nodejs and browser
 - [hyperquest](https://github.com/substack/hyperquest) - Streaming HTTP requests.
 - [spdy](https://github.com/indutny/node-spdy) - Creates SPDY servers with the same API as the built-in `https` module.
 - [Nock](https://github.com/pgte/nock) - A HTTP mocking and expectations library.


### PR DESCRIPTION
Rest is a fantastic promise-based http client, super clear and robust, with a number of built-in modules (called interceptors) to help configure defaults for your requests.