### PR TITLE
Add command-promise

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -181,6 +181,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [cli-cursor](https://github.com/sindresorhus/cli-cursor) - Toggle the CLI cursor.
 - [ascii-charts](https://github.com/jstrace/chart) - ASCII bar chart in the terminal.
 - [cfonts](https://github.com/dominikwilkowski/cfonts) - Sexy ASCII fonts for the console.
+- [Command](https://github.com/StreetStrider/command-promise) - Promise wrapper for child_process.exec.
 
 
 ### Package managers


### PR DESCRIPTION
This is my own lib which I use in deploying and automation to run shell scripts. In general: it makes `child_process.exec` return promise. It has some additional features:
* It flattens arrays and arguments list passed, so no need to `join` arguments or do `apply`. This allows to pass some hardcoded data (like command name, e.g. `ls`) and variable data (e.g. path, or array of paths).
* It has utils for transforming command output.
* It has simple form for inserting in promise flow and also `Command` can be `partial`led or `bind`ed and not depends on `this`.

I tried to notice some of features in description, but description should be not only descriptive, but also short, so I just put «promise wrapper», as I say above, this is not the only feature.
I'm not sure about section for this, but minimist here, so I put this stuff here too.

I was using this lib for a long time and it has good pack of tests.