### PR TITLE
Added Restberry to the web framework list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -156,7 +156,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Restify](http://mcavage.me/node-restify/) - A node framework built specifically to enable you to build correct REST web services.
 - [Derby](https://github.com/derbyjs/derby) - MVC framework, making it easy to write realtime, collaborative applications that run in both Node.js and browsers.
 - [Interfake](https://github.com/basicallydan/interfake) - Rapid prototyping framework for making mock HTTP APIs, with a Node, command-line and HTTP interface.
-- [Restberry](http://restberry.com) - Framework for setting up a RESTful JSON API by defining database models and applying CRUD APIs to them without needing to write any code.
+- [Restberry](http://restberry.com) - Framework for setting up RESTful JSON APIs, applied to your database models without needing to write any code.
 
 
 ### Command-line utilities

--- a/readme.md
+++ b/readme.md
@@ -156,6 +156,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Restify](http://mcavage.me/node-restify/) - A node framework built specifically to enable you to build correct REST web services.
 - [Derby](https://github.com/derbyjs/derby) - MVC framework, making it easy to write realtime, collaborative applications that run in both Node.js and browsers.
 - [Interfake](https://github.com/basicallydan/interfake) - Rapid prototyping framework for making mock HTTP APIs, with a Node, command-line and HTTP interface.
+- [Restberry](http://restberry.com) - Framework for setting up a RESTful JSON API by defining database models and applying CRUD APIs to them without needing to write any code.
 
 
 ### Command-line utilities


### PR DESCRIPTION
Links to Restberry:
- Homepage: http://restberry.com
- NPM: https://www.npmjs.org/package/restberry
- GitHub: https://github.com/materik/restberry

I've been developing and improving Restberry for almost a year. I have used it in a lot of my own projects and find issues that has strengthen the package after I've fixed them. I have an extensive test suite and will keep maintaining it and further improve it for the conceivable future.

What the package is really about is that you can create your database models and say that you want a create CRUD API call connected to the model. All you have to do is apply the API and all the code is written for you, from handling bad requests to authorisation to nice JSON outputs.