### PR TITLE
Add dotenv to Miscellaneous section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -541,6 +541,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [atom-shell](https://github.com/atom/atom-shell) - Cross-platform desktop application shell.
 - [agenda](https://github.com/rschmukler/agenda) - Lightweight job scheduling on MongoDB.
 - [node-bell](https://github.com/eleme/node-bell) - Real-time anomalies detection for periodic time series.
+- [dotenv](https://github.com/motdotla/dotenv) - Load environment variables from .env file.
 
 
 ## Resources


### PR DESCRIPTION
Hello, I would like to add `dotenv` project to Miscellaneous section.

It is a good practice to pass application configuration (e.g. db connection strings) via environment variables (12-factor app). But when you develop an application it won't be convenient to type all environment variables in terminal to launch your application (unless you are using some process management tool, however, that requires additional configuration). That's where `dotenv` project comes out. You can put all env. variables stuff in one file (`.env`) and load it with one line of code.