### PR TITLE
modhelp (Syntax highlighted node module readmes in terminal with ANSI-friendly pager)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [pjs](https://github.com/danielstjules/pjs) - Pipeable JavaScript. Quickly filter, map, and reduce from the terminal.
 - [license-checker](https://github.com/davglass/license-checker) - Check licenses of your app's dependencies.
 - [browser-run](https://github.com/juliangruber/browser-run) - Easily run code in a browser environment.
-
+- [modhelp](https://github.com/runvnc/modhelp) - Syntax-highlighted module READMEs in terminal with ANSI-friendly pager.
 
 ### Functional programming
 


### PR DESCRIPTION
https://github.com/runvnc/modhelp