### PR TITLE
Add node_pcap

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -378,6 +378,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 ### Network
 
+- [node_pcap](https://github.com/mranney/node_pcap) - Raw packet capture, decoding, and analysis.
 - [get-port](https://github.com/sindresorhus/get-port) - Get an available port.
 - [ipify](https://github.com/sindresorhus/ipify) - Get your public IP address.
 - [getmac](https://github.com/bevry/getmac) - Get the computer MAC address.


### PR DESCRIPTION
The `node_pcap` package is a awesome library for raw packet capture (Both live capturing and pcap file parsing), decoding, and analysis. It is a set of bindings from `libpcap` which is packet capture library used by programs like `tcpdump` or `wireshark`.

Here is the repo https://github.com/mranney/node_pcap and published package on NPM https://www.npmjs.com/package/pcap.

