### PR TITLE
Add `navit`, remove `Nightmare`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -455,7 +455,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [istanbul](https://github.com/gotwarlost/istanbul) - A code coverage tool that computes statement, line, function and branch coverage with module loader hooks to transparently add coverage when running tests.
 - [Sinon.JS](https://github.com/cjohansen/Sinon.JS) - Test spies, stubs and mocks.
 - [Karma](http://karma-runner.github.io) - Executes code in multiple real browsers.
-- [Nightmare](http://nightmarejs.org) - High-level PhantomJS wrapper that lets you automate browser tasks.
+- [navit](https://github.com/nodeca/navit) - PhantomJS wrapper for easy client tests scripting.
 
 
 ### Benchmarking


### PR DESCRIPTION
[navit](https://github.com/nodeca/navit) is  similar to [Nightmare](https://github.com/segmentio/nightmare) from your list, but has much more consistent API (including intermediate errors handle) and better phantomjs bridge. Don't know is it strong enougth for this list. But i'm sure you will see a big difference if start to use.