### PR TITLE
Add FutoIn AsyncSteps Reference Implementation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -275,6 +275,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 	- [js-csp](https://github.com/jlongster/js-csp) - Communicating sequential processes for JavaScript (like Clojurescript core.async, or Go).
 - Other
 	- [zone](https://github.com/strongloop/zone) - Provides a way to group and track resources and errors across asynchronous operations.
+	- [futoin-asyncsteps](https://github.com/futoin/core-js-ri-asyncsteps) - Adds classical linear program structure exceptions, timeouts, parallel execution, loops and job state/context.
 
 
 ### Streams


### PR DESCRIPTION
NPM Name: futoin-asyncsteps
Package: https://github.com/futoin/core-js-ri-asyncsteps

Please add FutoIn AsyncSteps reference implementation based on [FTN12: Async API v1.6](http://specs.futoin.org/final/preview/ftn12_async_api-1.html) specification.

The specification tries to create language-agnostic Async Steps pattern, supporting:
* basic chain of steps with associated error handler for each step in classical try-catch pattern
* unlimited number of inner steps and inner step levels
* on demand parallel execution of inner step
* job state/context variables
    * error code and optional error info for each exception
    * the last thrown exception
    * any arbitrary user-defined data
* "model" steps for efficient duplication avoiding closure creation overhead
* optional timeout for step and its sub-steps execution
* optional cancel handler (on timeout or external abort)
* async loops:
    * generic loop
    * forEach loop over object or array
    * repeat loop for fixed count of iterations
    * optional loop scope naming
    * break / continue [with optional scope name]
* designed for easy integration with other async frameworks and promises
* suitable for building simple to use async library interfaces without mess at invocation
