### PR TITLE
Add ObjectEventTarget

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -276,6 +276,8 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 	- [Highland.js](http://highlandjs.org) - Manages synchronous and asynchronous code easily, using nothing more than standard JavaScript and Node-like Streams.
 - Channels
 	- [js-csp](https://github.com/jlongster/js-csp) - Communicating sequential processes for JavaScript (like Clojurescript core.async, or Go).
+- Events
+	- [ObjectEventTarget](https://github.com/gartz/ObjectEventTarget) - Provide a prototype that add support to event listeners (with same behavior of EventTarget from DOMElements available on browsers).
 - Other
 	- [zone](https://github.com/strongloop/zone) - Provides a way to group and track resources and errors across asynchronous operations.
 


### PR DESCRIPTION
https://github.com/gartz/ObjectEventTarget

It worths because you can set it as prototype of constructor function and all instances will be able to listen for events you can dispatch from inside your object logic, just like you work with DOMElements, what is very well documented and reliable. And you don't need to create any special property in your object it works detecting the context of the object, and easy allow to that object be extended and still work.

Test coverage 99% and documented.