### PR TITLE
Propose adding moron.js to ORM category

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -455,6 +455,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 	- [Knex](http://knexjs.org) - A query builder for PostgreSQL, MySQL and SQLite3, designed to be flexible, portable, and fun to use.
 - Other
 	- [NeDB](https://github.com/louischatriot/nedb) - Embedded persistent database written in JavaScript.
+	- [Moron.js](https://github.com/Vincit/moron.js) - Declarative ORM built around [knex](https://github.com/tgriesser/knex) SQL query builder, similar to Bookshelf but with less Backbone.js style influence.
 
 
 ### Testing


### PR DESCRIPTION
I encountered it in [this article](http://www.vincit.fi/blog/introducing-moron-js-a-new-orm-for-node-js/) and it is well tested and appears well put together and I feel is a worthy submission.

[Here is an issue](https://github.com/Vincit/moron.js/issues/11) regarding its similary to Bookshelf