### PR TITLE
Add i2c-bus

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -222,6 +222,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [serialport](https://github.com/voodootikigod/node-serialport) - Access serial ports for reading and writing.
 - [usb](https://github.com/nonolith/node-usb) - USB library.
 - [cylon.js](http://cylonjs.com/) - Next generation robotics framework with support for 26 different platforms.
+- [i2c-bus](https://github.com/fivdi/i2c-bus) - I2C serial bus access.
 
 
 ### Templating


### PR DESCRIPTION
https://github.com/fivdi/i2c-bus

This package allows you to access any type of I2C device like accelerometers, compasses, and temperature sensors on single-board computers like the Raspberry Pi.
