### PR TITLE
Add link to npm-hub extension

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -658,6 +658,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 ### Tools
 
 - [GitHub Linker](https://chrome.google.com/webstore/detail/github-linker/jlmafbaeoofdegohdhinkhilhclaklkp) - Chrome extension that linkifies dependencies in package.json, .js, .jsx, .coffee and .md files on GitHub.
+- [npm-hub](https://chrome.google.com/webstore/detail/npm-hub/kbbbjimdjbjclaebffknlabpogocablj) - Chrome extension to display npm dependencies at the bottom of a repo's readme.
 
 ### Miscellaneous
 


### PR DESCRIPTION
This extension was mentioned in a recent NodeUp episode as an awesome tool for package discovery.

Definitely belongs here.