### PR TITLE
Add ttystudio to Command-line apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -103,6 +103,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [dark-mode](https://github.com/sindresorhus/dark-mode) - Toggle the Dark Mode in OS X 10.10 from the command-line.
 - [vantage](https://github.com/dthree/vantage) - Distributed, realtime CLI for your live app.
 - [rtail](https://github.com/kilianc/rtail) - Terminal output to the browser in seconds, using UNIX pipes.
+- [ttystudio](https://github.com/chjj/ttystudio) - Record your terminal and compile it to a GIF or APNG without any external dependencies, bash scripts, gif concatenation, etc.
 
 
 ### Functional programming


### PR DESCRIPTION
This adds [ttystudio](https://github.com/chjj/ttystudio).

> ttystudio differs from other terminal recorders in that:
>
> 1. It has its own built-in gif and apng writer, no imagemagick required. The writer now has built-in frame offset optimization.
> 2. It has a font parser to render the font during image writing so no terminal playback is required when writing the image (this also means no GUI is required at all - you can record on a remote machine via ssh).
> 3. No concatenation of hundreds of gif files required. ttystudio automatically writes out to one gif or apng.
> 4. No glitchy frames due to imperfect GUI recording of the playback or gif concatenation.
    ttystudio will record frames even if nothing is being updated on the screen.
