### PR TITLE
Add `mongo-url-utils`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -456,6 +456,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 	- [Knex](http://knexjs.org) - A query builder for PostgreSQL, MySQL and SQLite3, designed to be flexible, portable, and fun to use.
 - Other
 	- [NeDB](https://github.com/louischatriot/nedb) - Embedded persistent database written in JavaScript.
+	- [mongo-url-utils](https://github.com/seangarner/mongo-url-utils) - Parse url params into objects that can be passed to mongo collection methods.
 
 
 ### Testing


### PR DESCRIPTION
[mongo-url-utils](https://github.com/seangarner/mongo-url-utils) parses url params into objects which can be passed to the mongo find method.  Cleaner (IMO) and safer than just serialising a json object into the url.