### PR TITLE
Added bluebird-co

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -272,6 +272,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - Generators
 	- [co](https://github.com/visionmedia/co) - The ultimate generator based flow-control goodness.
 	- [suspend](https://github.com/jmar777/suspend) - Generator-based control flow that plays nice with callbacks, promises, and thunks.
+	- [bluebird-co](https://github.com/novacrazy/bluebird-co) - A set of high performance yield handlers for Bluebird coroutines.
 - Promises
 	- [native-promise-only](https://github.com/getify/native-promise-only) - A polyfill for native ES6 Promises.
 	- [Bluebird](https://github.com/petkaantonov/bluebird) - A fully featured promise library with focus on innovative features and performance.


### PR DESCRIPTION
Added [bluebird-co](https://github.com/novacrazy/bluebird-co) to readme. It's a high performance reimplementation of tj/co using yield handlers for [Bluebird coroutines](https://github.com/petkaantonov/bluebird/blob/master/API.md#promisecoroutinegeneratorfunction-generatorfunction---function) to handle asynchronous generators. 