### PR TITLE
Add rocky

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -134,6 +134,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [download](https://github.com/kevva/download) - Download and extract files effortlessly.
 - [wreck](https://github.com/hapijs/wreck) - HTTP Client Utilities.
 - [http-proxy](https://github.com/nodejitsu/node-http-proxy) - A full-featured HTTP proxy.
+- [rocky](https://github.com/h2non/rocky) - Featured, middleware-oriented HTTP proxy with traffic replay and intercept.
 
 
 ### Debugging / Profiling

--- a/readme.md
+++ b/readme.md
@@ -590,7 +590,8 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [remote-git-tags](https://github.com/sindresorhus/remote-git-tags) - Get tags from a remote git repo.
 - [dot-prop](https://github.com/sindresorhus/dot-prop) - Get a property from a nested object using a dot path.
 - [onetime](https://github.com/sindresorhus/onetime) - Only run a function once.
-- [nar](https://github.com/h2non/nar) - Creates self-contained executables binaries.
+- [nar](https://github.com/h2non/nar) - Create self-contained executable binaries.
+
 
 ## Resources
 

--- a/readme.md
+++ b/readme.md
@@ -131,7 +131,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [download](https://github.com/kevva/download) - Download and extract files effortlessly.
 - [wreck](https://github.com/hapijs/wreck) - HTTP Client Utilities.
 - [http-proxy](https://github.com/nodejitsu/node-http-proxy) - A full-featured HTTP proxy.
-- [rocky](https://github.com/h2non/rocky) - Pluggable and middleware-oriented HTTP/S proxy with traffic replay and more
+- [rocky](https://github.com/h2non/rocky) - Pluggable and middleware-oriented HTTP/S proxy with traffic replay and more.
 
 ### Debugging / Profiling
 
@@ -591,7 +591,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [remote-git-tags](https://github.com/sindresorhus/remote-git-tags) - Get tags from a remote git repo.
 - [dot-prop](https://github.com/sindresorhus/dot-prop) - Get a property from a nested object using a dot path.
 - [onetime](https://github.com/sindresorhus/onetime) - Only run a function once.
-- [nar](https://github.com/h2non/nar) - node.js application archive. Creates self-contained executables binaries of node.js/io.js packages
+- [nar](https://github.com/h2non/nar) - Creates self-contained executables binaries.
 
 ## Resources
 

--- a/readme.md
+++ b/readme.md
@@ -131,7 +131,6 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [download](https://github.com/kevva/download) - Download and extract files effortlessly.
 - [wreck](https://github.com/hapijs/wreck) - HTTP Client Utilities.
 - [http-proxy](https://github.com/nodejitsu/node-http-proxy) - A full-featured HTTP proxy.
-- [rocky](https://github.com/h2non/rocky) - Pluggable and middleware-oriented HTTP/S proxy with traffic replay and more.
 
 ### Debugging / Profiling
 

--- a/readme.md
+++ b/readme.md
@@ -132,6 +132,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [wreck](https://github.com/hapijs/wreck) - HTTP Client Utilities.
 - [http-proxy](https://github.com/nodejitsu/node-http-proxy) - A full-featured HTTP proxy.
 
+
 ### Debugging / Profiling
 
 - [node-inspector](https://github.com/node-inspector/node-inspector) - Debugger based on Blink Developer Tools.

--- a/readme.md
+++ b/readme.md
@@ -131,7 +131,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [download](https://github.com/kevva/download) - Download and extract files effortlessly.
 - [wreck](https://github.com/hapijs/wreck) - HTTP Client Utilities.
 - [http-proxy](https://github.com/nodejitsu/node-http-proxy) - A full-featured HTTP proxy.
-
+- [rocky](https://github.com/h2non/rocky) - Pluggable and middleware-oriented HTTP/S proxy with traffic replay and more
 
 ### Debugging / Profiling
 
@@ -591,7 +591,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [remote-git-tags](https://github.com/sindresorhus/remote-git-tags) - Get tags from a remote git repo.
 - [dot-prop](https://github.com/sindresorhus/dot-prop) - Get a property from a nested object using a dot path.
 - [onetime](https://github.com/sindresorhus/onetime) - Only run a function once.
-
+- [nar](https://github.com/h2non/nar) - node.js application archive. Creates self-contained executables binaries of node.js/io.js packages
 
 ## Resources
 


### PR DESCRIPTION
Like @sindresorhus recommended, one month after, here is the PR for [rocky](https://github.com/h2non/rocky)!

A couple of news about package evolution during this period:

- ~2K downloads in NPM
- Bumped two minor versions. Now in `0.3.x`.
- Significant new features, such as a new middleware layer, built-in retry logic and more.
- Major refactors. Now the package is more lightweight and has less dependencies.
- Improved test coverage

Hope it's all fine! Thanks.