### PR TITLE
Add `marko` to `Templating`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -235,6 +235,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Jade](https://github.com/visionmedia/jade) - High performance template engine heavily influenced by Haml.
 - [nunjucks](https://github.com/mozilla/nunjucks) - A powerful templating engine with inheritance, asynchronous control, and more (jinja2 inspired).
 - [EJS](https://github.com/mde/ejs) - Simple unopinionated templating language.
+- [marko](https://github.com/marko-js/marko) - A fast and lightweight HTML-based templating engine that compiles templates to CommonJS modules and supports streaming, async rendering and custom tags.
 
 
 ### Documentation


### PR DESCRIPTION
https://github.com/marko-js/marko

marko has some unique and awesome features:

- [Extremely fast](https://github.com/marko-js/templating-benchmarks)
- Lightweight (~3.75KB gzipped)
- Clean HTML syntax
- Custom tags and custom attributes
- Streaming, async and progressive HTML rendering
- Compiles templates to CommonJS modules that are [readable and debuggable](https://gist.github.com/patrick-steele-idem/0514b480219d1c9ed8d4)
- Server-side and client-side rendering (compatible with JavaScript module bundlers)
- Friendly compile-time error messages
- Can be used with [marko-widgets](https://github.com/marko-js/marko-widgets) for building stateful UI components with DOM diffing/patch, event delegation and declarative event binding

Sample template:

```xml
Hello ${data.name}!

<ul if="notEmpty(data.colors)">
    <li style="color: $color" for="color in data.colors">
        $color
    </li>
</ul>
<div else>
    No colors!
</div>
```

Code to render a template:

```javascript
require('marko/node-require').install();

var template = require('./hello-world.marko');

template.render({
        name: 'World',
        colors: ["red", "green", "blue"]
    },
    function(err, output) {
        console.log(output);
    });
```