### PR TITLE
Add `probe-image-size`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -331,6 +331,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [lwip](https://github.com/EyalAr/lwip) - Lightweight image processor which does not require ImageMagick.
 - [pica](https://github.com/nodeca/pica) - High quality & fast resize (lanczos3) in pure JS. Alternative to canvas drawImage(), when no pixelation allowed.
 - [is-progressive](https://github.com/sindresorhus/is-progressive) - Check if a JPEG image is progressive.
+- [probe-image-size](https://github.com/nodeca/probe-image-size) - Get the size of most image formats without a full download.
 
 
 ### Text


### PR DESCRIPTION
https://github.com/nodeca/probe-image-size

This package is useful for content generation, when you need to quickly detect the size of remote images. It starts download and immediately stops when got enougth info to detect image type and size.

We did it, because alternate implementations are outdated (fewer types support / pending PRs / memory use / ...). I think, this one is the most comfortable for developpers.