### PR TITLE
Add `url-unshort` and `embedza`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -381,9 +381,11 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 - [normalize-url](https://github.com/sindresorhus/normalize-url) - Normalize a URL.
 - [humanize-url](https://github.com/sindresorhus/humanize-url) - Humanize a URL: http://sindresorhus.com → sindresorhus.com.
+- [url-unshort](https://github.com/nodeca/url-unshort) - Expand shortened URLs.
 - [speakingurl](https://github.com/pid/speakingurl) - Generate a slug from a string with transliteration.
 - [linkify-it](https://github.com/markdown-it/linkify-it) - Link patterns detector with full unicode support.
 - [url-pattern](https://github.com/snd/url-pattern) - Easier than regex string matching patterns for URLs and other strings.
+- [embedza](https://github.com/nodeca/embedza) - Create HTML snippets/embeds from URLs using info from oEmbed, Open Graph, meta tags.
 
 
 ### Data validation


### PR DESCRIPTION
https://github.com/nodeca/url-unshort

Expand shortened URLs

https://github.com/nodeca/embedza

Create snippets by URL. Useful for content builders to replace youtube links with players, replace URL-s with page titles and so on. Configurable.