### PR TITLE
Add `event-wire`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -290,6 +290,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 	- [Highland.js](http://highlandjs.org) - Manages synchronous and asynchronous code easily, using nothing more than standard JavaScript and Node-like Streams.
 - Channels
 	- [js-csp](https://github.com/jlongster/js-csp) - Communicating sequential processes for JavaScript (like Clojurescript core.async, or Go).
+	- [event-wire](https://github.com/nodeca/event-wire) - Mediator with dynamic responsibility chains. Helps to groop async operations in lazy way.
 - Other
 	- [zone](https://github.com/strongloop/zone) - Provides a way to group and track resources and errors across asynchronous operations.
 


### PR DESCRIPTION
https://github.com/nodeca/event-wire

Decide yourself. That's a combination of mediator and responsibility chain paradygms + sugar for convenience. Simplifies creating apps with extendable logic. See [example](https://github.com/nodeca/nodeca.forum/blob/master/internal/forum/post_list.js) with before/after/on stuff.

This approach is used to build miracle nodeca app :).