### PR TITLE
Add `stream-faqs`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -703,6 +703,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 ### Cheatsheets
 
 - [Express.js](https://github.com/azat-co/cheatsheets/blob/master/express4/index.md)
+- [Stream FAQs](https://github.com/stephenplusplus/stream-faqs) - Answering common questions about streams, covering pagination, events, and more.
 
 ### Tools
 


### PR DESCRIPTION
I made a FAQ for streams that tries to address some common, real-world, production use cases, where left to the Node.js manual and google, you'd be lost.

https://github.com/stephenplusplus/stream-faqs

Hope this is the right fit, and the right category! (Cheatsheets?)