### PR TITLE
Add console-log-level to Logging

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -169,6 +169,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [winston](https://github.com/flatiron/winston) - A multi-transport async logging library.
 - [Bunyan](https://github.com/trentm/node-bunyan) - A simple and fast JSON logging library.
 - [intel](https://seanmonstar.github.io/intel) - A comprehensive logging library (handlers, filters, formatters, console injection).
+- [console-log-level](https://github.com/watson/console-log-level) - The most simple logger imaginable with support for log levels and custom prefixes.
 
 
 ### Command-line utilities


### PR DESCRIPTION
This adds [console-log-level](https://github.com/watson/console-log-level).
I'm not sure if it is a good candidate for the list but sometimes I only want a very simple logger.
`console-log-level` supports, imho, the only two features that are missing in the native `console` object to be a viable logger:
- the ability to set a log level.
- the ability to set a custom prefix for all log messages.