### PR TITLE
Add transceiver

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -307,6 +307,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 	- [Highland.js](http://highlandjs.org) - Manages synchronous and asynchronous code easily, using nothing more than standard JavaScript and Node-like Streams.
 - Channels
 	- [js-csp](https://github.com/jlongster/js-csp) - Communicating sequential processes for JavaScript (like Clojurescript core.async, or Go).
+	- [transceiver](https://github.com/risq/transceiver) - Channel based event bus with request/reply pattern, using promises.
 - Other
 	- [zone](https://github.com/strongloop/zone) - Provides a way to group and track resources and errors across asynchronous operations.
 


### PR DESCRIPTION
`transceiver` is a channel based event bus, written in ES6, using promises. It implements request/reply pattern (inspired by backbone.radio, with promises). It is designed to fit with bluebird API or any promise engine (but also works without any one as a traditional event bus).

The API is fully documented and 100% test covered :)