### PR TITLE
add dev-time-cli

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -125,6 +125,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [iponmap](https://github.com/nogizhopaboroda/iponmap) - IP location finder.
 - [Jsome](https://github.com/Javascipt/Jsome) - Pretty prints JSON with configurable colors and indentation.
 - [itunes-remote](https://github.com/mischah/itunes-remote) - Interactively control iTunes.
+- [dev-time](https://github.com/samverschueren/dev-time-cli) - Get the current local time of a GitHub user.
 
 
 ### Functional programming


### PR DESCRIPTION
Added [dev-time](https://github.com/samverschueren/dev-time-cli) to the list of command line apps.