### PR TITLE
Add diff2html-cli to Command-line apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -129,6 +129,7 @@
 - [text-meme](https://github.com/beatfreaker/text-meme-cli) - Generate a text meme.
 - [mobicon](https://github.com/samverschueren/mobicon-cli) - Mobile app icon generator.
 - [mobisplash](https://github.com/samverschueren/mobisplash-cli) - Mobile app splash screen generator.
+- [diff2html-cli](https://github.com/rtfpessoa/diff2html-cli) - Pretty git diff to HTML generator.
 
 
 ### Functional programming


### PR DESCRIPTION
[diff2html-cli](https://github.com/rtfpessoa/diff2html-cli) is an easy to use command-line application that creates pretty HTML diffs from git diff outputs, allowing a better code comparison in the browser.