### PR TITLE
Add diff2html to Parsing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -446,6 +446,7 @@
 - [excel-stream](https://github.com/dominictarr/excel-stream) - Streaming Excel spreadsheet to JSON parser.
 - [xml2js](https://github.com/Leonidas-from-XIV/node-xml2js) - XML to JavaScript object converter.
 - [Jison](http://zaach.github.io/jison/) - Friendly JavaScript parser generator. It shares genes with Bison, Yacc and family.
+- [diff2html](https://github.com/rtfpessoa/diff2html) - Git diff parser and HTML generator.
 
 
 ### Humanize


### PR DESCRIPTION
[diff2html](https://github.com/rtfpessoa/diff2html) is an simple parsing library for git diffs that creates a JSON representation of the diff and can also generate pretty HTML.