### PR TITLE
add multiline-billboard

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -219,6 +219,7 @@
 - [multispinner](https://github.com/codekirei/node-multispinner) - Multiple, simultaneous, individually controllable CLI spinners.
 - [omelette](https://github.com/f/omelette) - Shell autocompletion helper.
 - [cross-env](https://github.com/kentcdodds/cross-env) - Set environment variables cross-platform.
+- [multiline-billboard](https://github.com/codekirei/multiline-billboard) - Turn text into a fancy billboard for the terminal.
 
 
 ### Build tools


### PR DESCRIPTION
[multiline-billboard](https://github.com/codekirei/multiline-billboard) is a simple little module to turn a string or array of strings into a nicely-styled billboard.

Potentially useful for CLI apps that log to stdout to:

- call attention to something
- embellish a header