### PR TITLE
Add pg-promise

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -539,6 +539,7 @@
 	- [OpenRecord](https://github.com/PhilWaldmann/openrecord) - ORM for PostgreSQL, MySQL, SQLite3 and RESTful datastores. Similar to ActiveRecord.
 	- [orm2](https://github.com/dresende/node-orm2) - ORM for PostgreSQL, MariaDB, MySQL, Amazon Redshift, SQLite, MongoDB.
 	- [firenze](https://github.com/fahad19/firenze) - Adapter-based ORM for MySQL, Memory, Redis, localStorage and more.
+	- [pg-promise](https://github.com/vitaly-t/pg-promise) - PostgreSQL framework based on Promises/A+, for native SQL.
 - Query builder
 	- [Knex](http://knexjs.org) - A query builder for PostgreSQL, MySQL and SQLite3, designed to be flexible, portable, and fun to use.
 - Other


### PR DESCRIPTION
Adding [pg-promise](https://github.com/vitaly-t/pg-promise) - promise-based high-level framework for PostgreSQL.