### PR TITLE
Add algebra

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -443,7 +443,7 @@
 - [mathjs](https://github.com/josdejong/mathjs) - An extensive math library.
 - [math-sum](https://github.com/sindresorhus/math-sum) - Sum numbers.
 - [math-clamp](https://github.com/sindresorhus/math-clamp) - Clamp a number.
-- [algebra](https://github.com/fibo/algebra) - Vectors, Matrices, Tensors. Real, Complex, Quaternion.
+- [algebra-group](https://github.com/fibo/algebra-group) - Defines and algebra group structure.
 
 ### Date
 

--- a/readme.md
+++ b/readme.md
@@ -443,7 +443,7 @@
 - [mathjs](https://github.com/josdejong/mathjs) - An extensive math library.
 - [math-sum](https://github.com/sindresorhus/math-sum) - Sum numbers.
 - [math-clamp](https://github.com/sindresorhus/math-clamp) - Clamp a number.
-- [algebra-group](https://github.com/fibo/algebra-group) - Defines and algebra group structure.
+- [algebra](https://github.com/fibo/algebra) - Algebraic structures.
 
 ### Date
 

--- a/readme.md
+++ b/readme.md
@@ -439,12 +439,11 @@
 
 ### Math
 
-- [algebra](https://github.com/fibo/algebra) - Vectors, Matrices, Tensors. Real, Complex, Quaternion.
 - [ndarray](https://github.com/scijs/ndarray) - Multidimensional arrays.
 - [mathjs](https://github.com/josdejong/mathjs) - An extensive math library.
 - [math-sum](https://github.com/sindresorhus/math-sum) - Sum numbers.
 - [math-clamp](https://github.com/sindresorhus/math-clamp) - Clamp a number.
-
+- [algebra](https://github.com/fibo/algebra) - Vectors, Matrices, Tensors. Real, Complex, Quaternion.
 
 ### Date
 

--- a/readme.md
+++ b/readme.md
@@ -439,6 +439,7 @@
 
 ### Math
 
+- [algebra](https://github.com/fibo/algebra) - Vectors, Matrices, Tensors. Real, Complex, Quaternion.
 - [ndarray](https://github.com/scijs/ndarray) - Multidimensional arrays.
 - [mathjs](https://github.com/josdejong/mathjs) - An extensive math library.
 - [math-sum](https://github.com/sindresorhus/math-sum) - Sum numbers.


### PR DESCRIPTION
Hi, I added my algebra package.

Currently I am adding more documentation, tests and cleaning the code to prepare for a 1.0 version. The API is almost stable right now.

The algebra package let also define custom groups and rings, I did not added it in the description to keep it shorter.

Complex and Quaternion are implemented as composition algebras using the Cayley-Dickson operator over Reals, so also Octonion are implemented as well as Complexes over a custom field (for example using strings instead of numbers, if you find operators that respect the ring definition laws).

I hope algebra can enter the awesome node list.

Thanks,
Gianluca.