### PR TITLE
Add nano

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -534,6 +534,7 @@
 	- [PostgreSQL](https://github.com/brianc/node-postgres) - PostgreSQL client. Pure JavaScript and native libpq bindings.
 	- [MySQL](https://github.com/felixge/node-mysql) - MySQL client.
 	- [Redis](https://github.com/luin/ioredis) - Redis client.
+	- [nano](https://github.com/dscape/nano) - A minimalistic client for CouchDB.
 - ODM / ORM
 	- [Bookshelf](http://bookshelfjs.org) - ORM for PostgreSQL, MySQL and SQLite3 in the style of Backbone.js.
 	- [Massive](https://github.com/robconery/massive-js) - PostgreSQL data access tool.


### PR DESCRIPTION
Added nano, a minimalistic CouchDB driver for Node.js.