### PR TITLE
Rename Jade to Pug

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -290,7 +290,7 @@
 - [handlebars.js](https://github.com/wycats/handlebars.js) - A superset of Mustache templates which adds powerful features like helpers and more advanced blocks.
 - [hogan.js](http://twitter.github.io/hogan.js/) - Twitter's small, fast, phase-separated compiler for Mustache templates.
 - [EJS](https://github.com/mde/ejs) - Simple unopinionated templating language.
-- [Jade](https://github.com/jadejs/jade) - High-performance template engine heavily influenced by Haml.
+- [Pug (formerly Jade)](https://github.com/pugjs/pug) - High-performance template engine heavily influenced by Haml.
 
 
 ### Web frameworks


### PR DESCRIPTION
The project is being renamed due to trademark claims made on Jade: https://github.com/pugjs/pug/issues/2184