### PR TITLE
Replace bell with banshee

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -754,7 +754,7 @@
 - [remote-git-tags](https://github.com/sindresorhus/remote-git-tags) - Get tags from a remote git repo.
 - [semver](https://github.com/npm/node-semver) - [semver](http://semver.org) parser.
 - [nar](https://github.com/h2non/nar) - Create self-contained executable binaries.
-- [node-bell](https://github.com/eleme/bell.js) - Real-time anomalies detection for periodic time series.
+- [banshee](https://github.com/eleme/banshee) - Real-time anomalies detection for periodic time series.
 - [Faker.js](https://github.com/Marak/Faker.js) - Generate massive amounts of fake data.
 - [nodegit](https://github.com/nodegit/nodegit) - Native bindings to Git.
 - [json-strictify](https://github.com/pigulla/json-strictify) - Safely serialize a value to JSON without data loss or going into an infinite loop.


### PR DESCRIPTION
Bell.js is [no longer maintained](https://github.com/eleme/bell.js), and banshee is the [recommended
replacement](https://godoc.org/github.com/eleme/banshee#hdr-Migrate_from_bell).  As such, list banshee in bell's place.