### PR TITLE
Add Lux

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -311,6 +311,7 @@
 - [Restberry](http://restberry.com) - Framework for setting up RESTful JSON APIs, applied to your database models without needing to write any code.
 - [Catberry](http://catberry.org) - Framework with Flux architecture, isomorphic web-components, and progressive rendering.
 - [ThinkJS](https://thinkjs.org) - Framework with ES2015+ support, WebSockets, REST API.
+- [Lux](https://github.com/postlight/lux) - MVC style framework with modern syntax and full [JSON API](http://jsonapi.org/) support out of the box.
 
 
 ### Documentation


### PR DESCRIPTION
[Lux](https://github.com/postlight/lux) is an opinionated web framework that has it's roots in frustration over how much we tend to bike-shed over "solved problems" when building a large API with Node.js. 