### PR TITLE
Add ctrace

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -209,6 +209,7 @@
 - [locus](https://github.com/alidavut/locus) - Starts a REPL at runtime that has access to all variables.
 - [bugger](https://github.com/buggerjs/bugger) - Provides Chrome Devtools bindings to debug programs in Chrome.
 - [0x](https://github.com/davidmarkclements/0x) - Flamegraph profiling.
+- [ctrace](https://github.com/automation-stack/ctrace) - Well-formatted and improved trace system calls and signals (when the debugger does not help).
 
 
 ### Logging


### PR DESCRIPTION
Well-formatted and improved trace system calls and signals (when the debugger does not help).

```ctrace``` are indispensable in the following cases
   - Debugging complex performance issues or not identified unhandled errors and exceptions in own code or someone else's code
   - Learning OS kernel