### PR TITLE
Add RegEx-DoS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -586,6 +586,7 @@
 
 - [snyk](https://github.com/Snyk/snyk) - CLI and build-time tool to find & fix vulnerable npm dependencies.
 - [nsp](https://github.com/nodesecurity/nsp) - CLI tool to identify known vulnerabilities in your project.
+- [RegEx-DoS](https://github.com/jagracey/RegEx-DoS) - CLI tool to identify possible regex denial of service (ReDos) vulnerabilities in your project.
 
 
 ### Benchmarking


### PR DESCRIPTION
 It is important to prevent ReDoS attacks. Here is a CLI tool to identify possible regex denial of service (ReDos) vulnerabilities in your project.