### PR TITLE
Lock your screen via CLI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -162,6 +162,7 @@
 - [terminal-recorder](https://github.com/cortezcristian/terminal-recorder) - Record your terminal usage and export it to interactive HTML.
 - [jscpd](https://github.com/kucherenko/jscpd) - Copy/paste detector for source code.
 - [atmo](https://github.com/Raathigesh/Atmo) - Server-side API mocking.
+- [lockscreen-cli](https://github.com/michaelzoidl/lockscreen-cli) - Lock your screen via CLI
 
 
 ### Functional programming

--- a/readme.md
+++ b/readme.md
@@ -162,7 +162,7 @@
 - [terminal-recorder](https://github.com/cortezcristian/terminal-recorder) - Record your terminal usage and export it to interactive HTML.
 - [jscpd](https://github.com/kucherenko/jscpd) - Copy/paste detector for source code.
 - [atmo](https://github.com/Raathigesh/Atmo) - Server-side API mocking.
-- [lockscreen-cli](https://github.com/michaelzoidl/lockscreen-cli) - Lock your screen via CLI
+- [lockscreen-cli](https://github.com/michaelzoidl/lockscreen-cli) - Lock your screen via CLI.
 
 
 ### Functional programming


### PR DESCRIPTION
Hi, i've written some CLI tool which can lock your screen via a simple `$ lockscreen` command.
It's useful when you're working in an coworking office where you have/should lock your screen when leaving for e.g. lunch. 

I know you can use a shortcut on mac or activate the keychain thing in the tray-bar where you can find some "Lock Screen" function... but: _Command Line is Life, Command Line is Love. <3_ 

The package [michaelzoidl/lockscreen-cli](https://github.com/michaelzoidl/lockscreen-cli) is not TDD because it builds on [michaelzoidl/lockscreen](https://github.com/michaelzoidl/lockscreen) which is TDD.