### PR TITLE
Add Microsoft Node.js Guidelines

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -882,6 +882,7 @@
 - [node-module-boilerplate](https://github.com/sindresorhus/node-module-boilerplate) - Boilerplate to kickstart creating a node module.
 - [generator-nm](https://github.com/sindresorhus/generator-nm) - Scaffold out a node module.
 - [awesome-cross-platform-nodejs](https://github.com/bcoe/awesome-cross-platform-nodejs) - Resources for writing and testing cross-platform code.
+- [Microsoft Node.js Guidelines](https://github.com/Microsoft/nodejs-guidelines) - Tips, tricks, and resources for working with Node.js on Microsoft platforms.
 
 
 ## License


### PR DESCRIPTION
Adds a link to the Microsoft Node.js Guidelines under miscellaneous (I work on Node.js at Microsoft.) These guidelines help developers work with Node.js on Microsoft platforms, including Windows and Azure.