### PR TITLE
Added node-email-verification to email section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -624,6 +624,7 @@
 
 ### Email
 
+- [Node Email Verification](https://github.com/whitef0x0/node-email-verification) - The fastest way to add email-based user account verification to MEAN projects.
 - [Nodemailer](https://github.com/andris9/Nodemailer) - The fastest way to handle email.
 - [emailjs](https://github.com/eleith/emailjs) - Send text/HTML emails with attachments to any SMTP server.
 

--- a/readme.md
+++ b/readme.md
@@ -624,10 +624,9 @@
 
 ### Email
 
-- [Node Email Verification](https://github.com/whitef0x0/node-email-verification) - The fastest way to add email-based user account verification to MEAN projects.
 - [Nodemailer](https://github.com/andris9/Nodemailer) - The fastest way to handle email.
 - [emailjs](https://github.com/eleith/emailjs) - Send text/HTML emails with attachments to any SMTP server.
-
+- [Node Email Verification](https://github.com/whitef0x0/node-email-verification) - Add email-based user account verification to any MEANjs server.
 
 ### Job queues
 

--- a/readme.md
+++ b/readme.md
@@ -626,7 +626,7 @@
 
 - [Nodemailer](https://github.com/andris9/Nodemailer) - The fastest way to handle email.
 - [emailjs](https://github.com/eleith/emailjs) - Send text/HTML emails with attachments to any SMTP server.
-- [Node Email Verification](https://github.com/whitef0x0/node-email-verification) - Add email-based user account verification to any MEANjs server.
+- [Node Email Verification](https://github.com/whitef0x0/node-email-verification) - Add email-based user account verification to any MEAN server.
 
 ### Job queues
 


### PR DESCRIPTION
Added [node-email-verification](github.com/whitef0x0/node-email-verification), a library that allows you to easily add email verification to a MEAN (Mongo Express Angular Node) stack app in seconds. 

I think it should be added as it is a useful addition to any MEAN project and is currently actively developed and used by thousands of projects.