### PR TITLE
Adding manakin to the list of command-line utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -266,6 +266,7 @@
 - [yargs](https://github.com/yargs/yargs) - Command-line parser that automatically generates an elegant user-interface.
 - [liftoff](https://github.com/js-cli/js-liftoff) - Bootstrapping tool for building command-line app.
 - [listr](https://github.com/samverschueren/listr) - Terminal task list.
+- [manakin](https://github.com/vitaly-t/manakin) - Prime colors for your console — quick & safe.
 
 
 ### Build tools


### PR DESCRIPTION
[Manakin](https://github.com/vitaly-t/manakin) - adds prime colors to your Node.js console output, in the most simple and safe way.

* It can set colors either locally or globally (by overriding `console`)
* No need to mess with colors, very easy to use
* Consistent formatting with the standard `console` output
* Consistent use of `stdout` and `stderr`
* Super-easy extensibility