### PR TITLE
Add nodejs-traceroute to Network section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -550,6 +550,7 @@
 - [ipify](https://github.com/sindresorhus/ipify) - Get your public IP address.
 - [getmac](https://github.com/bevry/getmac) - Get the computer MAC address.
 - [polo](https://github.com/mafintosh/polo) - Zero-config service discovery.
+- [nodejs-traceroute](https://github.com/zulhilmizainuddin/nodejs-traceroute) - Wrapper around tracert and traceroute process.
 
 
 ### Database


### PR DESCRIPTION
Link: https://github.com/zulhilmizainuddin/nodejs-traceroute

Execute and retrieve results of tracert in Windows and traceroute in Linux from a Node.js program.