### PR TITLE
Add pino

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -232,6 +232,7 @@
 - [intel](http://seanmonstar.github.io/intel/) - A comprehensive logging library (handlers, filters, formatters, console injection).
 - [console-log-level](https://github.com/watson/console-log-level) - The most simple logger imaginable with support for log levels and custom prefixes.
 - [storyboard](https://github.com/guigrpa/storyboard) - End-to-end, hierarchical, real-time, colorful logs and stories.
+- [pino](https://github.com/mcollina/pino) - Extremely fast logger inspired by Bunyan. It also includes a shell utility to pretty-print its log files.
 
 
 ### Command-line utilities


### PR DESCRIPTION
`pino` is a [faster](https://github.com/mcollina/pino#benchmarks) alternative to `bunyan`. Here is an interesting slide deck talking about why it was created and showing some benchmarks:

- https://mcollina.github.io/the-cost-of-logging/