### PR TITLE
add timeago.js & pys

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -454,6 +454,7 @@
 - [parse-columns](https://github.com/sindresorhus/parse-columns) - Parse text columns, like the output of Unix commands.
 - [hanging-indent](https://github.com/codekirei/hanging-indent) - Format a string into a hanging-indented paragraph.
 - [matcher](https://github.com/sindresorhus/matcher) - Simple wildcard matching.
+- [pys](https://github.com/hustcc/pys) - Simple(~700b) javascript library to engance String.substring / Array.slice.
 
 
 ### Number
@@ -479,6 +480,7 @@
 - [Moment Timezone](http://momentjs.com/timezone/) - IANA Time Zone Database + Moment.js.
 - [dateformat](https://github.com/felixge/node-dateformat) - Date formatting.
 - [tz-format](https://github.com/samverschueren/tz-format) - Format a date with timezone: `2015-11-30T10:40:35+01:00`.
+- [timeago.js](https://github.com/hustcc/timeago.js) - Tiny(~2kb) library used to format date with `*** time ago` statement.
 
 
 ### URL


### PR DESCRIPTION
[timeago.js](https://github.com/hustcc/timeago.js) is a tiny(~1.75kb) library used to format date with `*** time ago` statement. eg: '3 hours ago'. No dependences & localization & tiny.

[pys](https://github.com/hustcc/pys) is a ~700b javascript library to engance String.substring / Array.slice with python slice style.