### PR TITLE
Add valvelet

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -373,6 +373,7 @@
 	- [rfpify](https://github.com/samverschueren/rfpify) - Promisify a result-first callback-style function.
 	- [delay](https://github.com/sindresorhus/delay) - Delay a promise a specified amount of time.
 	- [promise-memoize](https://github.com/nodeca/promise-memoize) - Memoize promise-returning functions, with expire and prefetch.
+	- [valvelet](https://github.com/lpinca/valvelet) - Limit the execution rate of a promise-returning function.
 - Callbacks
 	- [each-async](https://github.com/sindresorhus/each-async) - Async concurrent iterator like forEach.
 	- [async](https://github.com/caolan/async) - Provides straight-forward, powerful functions for working with asynchronicity.


### PR DESCRIPTION
This adds [valvelet](https://github.com/lpinca/valvelet), a small utility to limit the execution rate of a function. It works seamlessly with promise-returning functions. It is useful for scenarios such as REST APIs consumption where the amount of requests per unit of time should not exceed a given threshold.