### PR TITLE
Add lessmd

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -171,6 +171,7 @@
 - [jscpd](https://github.com/kucherenko/jscpd) - Copy/paste detector for source code.
 - [atmo](https://github.com/Raathigesh/Atmo) - Server-side API mocking.
 - [auto-install](https://github.com/siddharthkp/auto-install) - Auto installs dependencies as you code.
+- [lessmd] (https://github.com/linuxenko/lessmd) - Markdown for console.
 
 
 ### Functional programming

--- a/readme.md
+++ b/readme.md
@@ -171,7 +171,7 @@
 - [jscpd](https://github.com/kucherenko/jscpd) - Copy/paste detector for source code.
 - [atmo](https://github.com/Raathigesh/Atmo) - Server-side API mocking.
 - [auto-install](https://github.com/siddharthkp/auto-install) - Auto installs dependencies as you code.
-- [lessmd] (https://github.com/linuxenko/lessmd) - Markdown for console.
+- [lessmd](https://github.com/linuxenko/lessmd) - Markdown in the terminal.
 
 
 ### Functional programming


### PR DESCRIPTION
[lessmd](https://lessmd.js.org/) is often used for converting mardown into highlighted document for terminal, as well as a cli pager (viewer) for markdown.
