### PR TITLE
Add lowdb

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -589,6 +589,7 @@
 	- [Knex](http://knexjs.org) - A query builder for PostgreSQL, MySQL and SQLite3, designed to be flexible, portable, and fun to use.
 - Other
 	- [NeDB](https://github.com/louischatriot/nedb) - Embedded persistent database written in JavaScript.
+	- [Lowdb](https://github.com/typicode/lowdb) - A small JavaScript database powered by Lodash. Supports Node and the browser.
 
 
 ### Testing


### PR DESCRIPTION
Hi,

[Lowdb](https://github.com/typicode/lowdb) is a small database built on Lodash API. It's simple and works well when you need a local database for a CLI, small server or Electron app.

It's also flexible, you can use custom format, storage, etc... and add methods.
