### PR TITLE
Adds a link to ulog

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -234,6 +234,7 @@
 - [console-log-level](https://github.com/watson/console-log-level) - The most simple logger imaginable with support for log levels and custom prefixes.
 - [storyboard](https://github.com/guigrpa/storyboard) - End-to-end, hierarchical, real-time, colorful logs and stories.
 - [pino](https://github.com/mcollina/pino) - Extremely fast logger inspired by Bunyan.
+- [ulog](https://github.com/download/ulog) - Microscopically small universal logger, like debug with log levels.
 
 
 ### Command-line utilities


### PR DESCRIPTION
[ulog](https://github.com/download/ulog) is a universal logging library that combines features from the popular [debug](https://github.com/visionmedia/debug) utility with log levels, creating a more generally applicable logger. It also adds better browser support.

#### How this project came about and why I think it should be on this list
When I started developing in Javascript I created a small logging shim to wrap the console for situations where it was not available. When I started developing in Node, I tried a bunch of logging frameworks, but none satisfied my needs. So I modified my own library based on some new ideas I had seen and created [picolog](https://github.com/download/picolog). I have been using that for about a year. In this time I discovered some things that lead to ulog:

1. I found that it's natural for the default log level to be INFO on Node, but WARN on the browser
2. When there are lots of modules doing logging, you end up wanting to see only the messages from some of them
3. I discovered the popularity of debug. It's named modules and filtering idea is brilliant, but I did not like the fact that this was purely aimed at debugging. I wanted something more general purpose.
4. I stumbled on the author of `ulog`, a project started but never completed. He agreed to let me use the name

So I created ulog. I have been using it for a month now. I have some ideas to make it even better (mostly I want to be able to use it as an alias for debuug so I can force packages using debug to use ulog instead), but I feel it's already full-featured so I'll do that when the need arises.

The package has a test suite and CI integration. I tested it's predecessor on platforms such as Nashorn and with loaders such as require js to make sure it is truly universal and I've been personally using and tweaking it for a very long time.