### PR TITLE
Add idoit to Job queues section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -658,6 +658,7 @@
 - [kue](https://github.com/Automattic/kue) - Priority job queue backed by Redis.
 - [bull](https://github.com/OptimalBits/bull) - Persistent job and message queue.
 - [agenda](https://github.com/rschmukler/agenda) - Lightweight job scheduling on MongoDB.
+- [idoit](https://github.com/nodeca/idoit) - Redis backed job queue engine with advanced job control.
 
 
 ### Node.js management


### PR DESCRIPTION
https://github.com/nodeca/idoit (job queue)

I know you like clear & short package descriptions, but don't know how to explain everything in one phrase because topic is complicated. Here are details:

- package is inspired by Celery & Akka ideas
- tasks can be chained & grouped
- special "iterator" feature to generate chunks for huge ranges on demand
  - in short - allows avoid "skip" in db selects when you need to create chunks of equal size. "skip"-s are very slow on huge sets. This feature is unique for this package.
- worker pools instead of "priorities" - no reinventing system scheduler to separate heavy tasks.
- "transactional" redis updates - data is guaranteed to be eventually consistent. That's not as easy as it seems.

Of cause, popular features like sheduler, postponed execution and others exist too. I pointed only to the most important things.