### PR TITLE
Add pglistend in the database section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -590,6 +590,7 @@
 - Other
 	- [NeDB](https://github.com/louischatriot/nedb) - Embedded persistent database written in JavaScript.
 	- [Lowdb](https://github.com/typicode/lowdb) - Small JavaScript database powered by Lodash.
+	- [pglistend](https://github.com/kabirbaidhya/pglistend) - A lightweight PostgresSQL `LISTEN`/`NOTIFY` daemon built on top of `node-postgres`.
 
 
 ### Testing


### PR DESCRIPTION
A lightweight Postgres LISTEN Daemon built on top of [node](https://nodejs.org/en/), [node-postgres](https://github.com/brianc/node-postgres) and [systemd](https://wiki.debian.org/systemd).

It's a very simple yet generic daemon application that could be used in any project that makes use of Postgres' `LISTEN`/`NOTIFY` feature.

It runs as a background process that does `LISTEN` on the configured channels on a database and allows to perform custom actions on receiving [`NOTIFY`](https://www.postgresql.org/docs/9.1/static/sql-notify.html) signals on those channels.

Find more information here in the [README](https://github.com/kabirbaidhya/pglistend).