### PR TITLE
Add cctz

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -488,6 +488,7 @@
 - [Moment Timezone](http://momentjs.com/timezone/) - IANA Time Zone Database + Moment.js.
 - [dateformat](https://github.com/felixge/node-dateformat) - Date formatting.
 - [tz-format](https://github.com/samverschueren/tz-format) - Format a date with timezone: `2015-11-30T10:40:35+01:00`.
+- [cctz](https://github.com/floatdrop/node-cctz) - Fast parsing, formatting and timezone conversation for dates.
 
 
 ### URL

--- a/readme.md
+++ b/readme.md
@@ -493,7 +493,7 @@
 - [dateformat](https://github.com/felixge/node-dateformat) - Date formatting.
 - [tz-format](https://github.com/samverschueren/tz-format) - Format a date with timezone: `2015-11-30T10:40:35+01:00`.
 - [date-fns](https://github.com/date-fns/date-fns) - Modern date utility.
-- [cctz](https://github.com/floatdrop/node-cctz) - Fast parsing, formatting and timezone conversation for dates.
+- [cctz](https://github.com/floatdrop/node-cctz) - Fast parsing, formatting, and timezone conversation for dates.
 
 
 ### URL


### PR DESCRIPTION
Binding to Google [CCTZ](https://github.com/google/cctz) library for extremely fast parsing, formatting and manipulating of dates. This already saved us 30% of CPU utilisation by switching from `moment-timezone` to [`cctz`](http://github.com/floatdrop/node-cctz).