### PR TITLE
Add localtunnel

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -171,7 +171,7 @@
 - [jscpd](https://github.com/kucherenko/jscpd) - Copy/paste detector for source code.
 - [atmo](https://github.com/Raathigesh/Atmo) - Server-side API mocking.
 - [auto-install](https://github.com/siddharthkp/auto-install) - Auto installs dependencies as you code.
-- [localtunnel](https://github.com/localtunnel/localtunnel) - Exposes your localhost webservice/webapp to the world. No need to mess with DNS or deploy to the cloud.
+- [localtunnel](https://github.com/localtunnel/localtunnel) - Expose your localhost to the world.
 
 
 ### Functional programming

--- a/readme.md
+++ b/readme.md
@@ -171,6 +171,7 @@
 - [jscpd](https://github.com/kucherenko/jscpd) - Copy/paste detector for source code.
 - [atmo](https://github.com/Raathigesh/Atmo) - Server-side API mocking.
 - [auto-install](https://github.com/siddharthkp/auto-install) - Auto installs dependencies as you code.
+- [localtunnel](https://github.com/localtunnel/localtunnel) - Exposes your localhost webservice/webapp to the world. No need to mess with DNS or deploy to the cloud.
 
 
 ### Functional programming


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆

1. Run a localhost webapp / webservice (may be express app)
2. Run localtunnel on the express app port using 
       `lt --port <port>`
3. A unique url is generated to share your webservice to the world.
      `https://<sub-domain>.localtunnel.me`
4. Share the url and your express app is exposed to everyone. Useful for demonstrations. Enjoy