### PR TITLE
Add unhomoglyph

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -463,6 +463,7 @@
 - [parse-columns](https://github.com/sindresorhus/parse-columns) - Parse text columns, like the output of Unix commands.
 - [hanging-indent](https://github.com/codekirei/hanging-indent) - Format a string into a hanging-indented paragraph.
 - [matcher](https://github.com/sindresorhus/matcher) - Simple wildcard matching.
+- [unhomoglyph](https://github.com/nodeca/unhomoglyph) - Normalize similar unicode characters.
 
 
 ### Number

--- a/readme.md
+++ b/readme.md
@@ -463,7 +463,7 @@
 - [parse-columns](https://github.com/sindresorhus/parse-columns) - Parse text columns, like the output of Unix commands.
 - [hanging-indent](https://github.com/codekirei/hanging-indent) - Format a string into a hanging-indented paragraph.
 - [matcher](https://github.com/sindresorhus/matcher) - Simple wildcard matching.
-- [unhomoglyph](https://github.com/nodeca/unhomoglyph) - Normalize similar unicode characters.
+- [unhomoglyph](https://github.com/nodeca/unhomoglyph) - Normalize visually similar unicode characters.
 
 
 ### Number


### PR DESCRIPTION
https://github.com/nodeca/unhomoglyph

This package "normalize" string look by replace all homoglyphs with base characters (`AΑАᎪᗅᴀꓮ` -> `AAAAAAA`).

That's useful to detect similar strings. For example, if you wish to prohibit "duplicates" with confusing nicknames and so on.

