### PR TITLE
Add oboe into streams section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -419,6 +419,7 @@
 - [readable-stream](https://github.com/nodejs/readable-stream) - Mirror of Streams2 and Streams3 implementations in core.
 - [through2-concurrent](https://github.com/almost/through2-concurrent) - Transform object streams concurrently.
 - [graphicsmagick-stream](https://github.com/e-conomic/graphicsmagick-stream) - Fast conversion/scaling of images using a pool of long lived GraphicsMagick processes.
+- [oboe](https://github.com/jimhigson/oboe.js) - A streaming approach to JSON by parsing objects in the source stream before it completes.
 
 
 ### Real-time

--- a/readme.md
+++ b/readme.md
@@ -419,7 +419,7 @@
 - [readable-stream](https://github.com/nodejs/readable-stream) - Mirror of Streams2 and Streams3 implementations in core.
 - [through2-concurrent](https://github.com/almost/through2-concurrent) - Transform object streams concurrently.
 - [graphicsmagick-stream](https://github.com/e-conomic/graphicsmagick-stream) - Fast conversion/scaling of images using a pool of long lived GraphicsMagick processes.
-- [oboe](https://github.com/jimhigson/oboe.js) - A streaming approach to JSON by parsing objects in the source stream before it completes.
+- [oboe](https://github.com/jimhigson/oboe.js) - Streaming approach to JSON by parsing objects in the source stream before it completes.
 
 
 ### Real-time


### PR DESCRIPTION
Basically reopens #587 now that I'm actively working on oboe.js. I've put oboe into the streams section as opposed to HTTP. I did that because while oboe can make HTTP requests, in node it is more abstract and able to handle any readable stream. In fact, I think a preferred interface is to make a request and pass the response stream to oboe. It's worth noting that on the browser side, right now oboe just has the ability to make the requests on its own, so it would fit into the HTTP section