### PR TITLE
add bee queue to job queues section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -667,6 +667,8 @@
 - [bull](https://github.com/OptimalBits/bull) - Persistent job and message queue.
 - [agenda](https://github.com/rschmukler/agenda) - Lightweight job scheduling on MongoDB.
 - [idoit](https://github.com/nodeca/idoit) - Redis-backed job queue engine with advanced job control.
+- [bee-queue](https://github.com/LewisJEllis/bee-queue) - Simple, fast, robust job queue backed by Redis.
+
 
 
 ### Node.js management


### PR DESCRIPTION
https://github.com/LewisJEllis/bee-queue

Another Redis-backed job queue but has some unique features. 

- Bee-Queue combines Bull's simplicity and robustness + Kue's ability to send events back to job creators. 
- faster than Bull and Kue based on benchmark
- Robust: designed with concurrency, atomicity, and failure in mind