### PR TITLE
Add NW.js

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -766,6 +766,7 @@ Check out my [blog](https://blog.sindresorhus.com) 🦄 or say *hi* on [Twitter]
 
 - [execa](https://github.com/sindresorhus/execa) - Better `child_process`.
 - [cheerio](https://github.com/cheeriojs/cheerio) - Fast, flexible, and lean implementation of core jQuery designed specifically for the server.
+- [NW.js](https://github.com/nwjs/nw.js) - Build cross-platform desktop applications using modern web technologies.
 - [Electron](https://github.com/atom/electron) - Build cross platform desktop apps with web technologies. *(You might like [awesome-electron](https://github.com/sindresorhus/awesome-electron))*
 - [opn](https://github.com/sindresorhus/opn) - Opens stuff like websites, files, executables.
 - [hasha](https://github.com/sindresorhus/hasha) - Hashing made simple. Get the hash of a buffer/string/stream/file.


### PR DESCRIPTION
**Upsides of NW.js**:

* NW.js has been around 5 years longer than Electron.
* It's updated faster and more often (within 24 hours of any Node or Chromium release).
* It has new features added faster.
* It produces smaller distribution sizes.
* Supports twice as many operating systems (including much better modern Linux and legacy Windows support).
* It supports V8 snapshots which allow **true** source protection (Electron only allows for obscuring how to access the source code, but anyone with a basic familiarity can still retrieve it).
* Considerably easier to use (simpler setup, more ways to package for distribution, more robust and intuitive API).
* Allows for either HTML *or* JS as the entry point.

**Downsides of NW.js:**

* NW.js is a terrible name (No marketing/branding)
* The logo looks outdated (No marketing/branding)
* The website could look better (No marketing/branding)
* Smaller community
* Smaller ecosystem

It's major downside is that it doesn't have GitHub advertising it, so it would be nice for it not to be excluded from this list, as it is clearly better in many areas and deserves more notoriety.