### PR TITLE
Add mz

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -383,6 +383,7 @@ Check out my [blog](https://blog.sindresorhus.com) 🦄 or say *hi* on [Twitter]
 	- [promise-memoize](https://github.com/nodeca/promise-memoize) - Memoize promise-returning functions, with expire and prefetch.
 	- [valvelet](https://github.com/lpinca/valvelet) - Limit the execution rate of a promise-returning function.
 	- [p-map](https://github.com/sindresorhus/p-map) - Map over promises concurrently.
+	- [mz](https://github.com/normalize/mz) - Modernize node.js to current ECMAScript standards.
 	- [More…](https://github.com/wbinnssmith/awesome-promises)
 - Observables
 	- [zen-observable](https://github.com/zenparsing/zen-observable) - Implementation of Observables.


### PR DESCRIPTION
[mz](https://github.com/normalize/mz) modernizes the node.js API to current ECMAScript standards by providing promisified versions of most of node.js's methods.

This is similar to a couple of projects on the list like fs-jetpack and sander, but I think it's better because it promisifies the whole node.js API, doesn't try to change the node.js API and seems to have a lot more usage.

I'll let you decide if anything should be removed.