### PR TITLE
add module-invalidate in Miscellaneous section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -797,6 +797,7 @@ Check out my [blog](https://blog.sindresorhus.com) 🦄 or say *hi* on [Twitter]
 - [simplecrawler](https://github.com/cgiffard/node-simplecrawler) - Event driven web crawler.
 - [jsdom](https://github.com/tmpvar/jsdom) - JavaScript implementation of HTML and the DOM.
 - [hypernova](https://github.com/airbnb/hypernova) - Server-side rendering your JavaScript views.
+- [module-invalidate](https://github.com/FranckFreiburger/module-invalidate) - Invalidate modules loaded through `require()` and automatically reload them on further access.
 
 
 ## Resources


### PR DESCRIPTION
module-invalidate allows you to invalidate a given module (or all modules) and make it automatically reloaded on further access, no need to call require() again.