### PR TITLE
Add pigpio

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -304,6 +304,7 @@ Check out my [blog](https://blog.sindresorhus.com) 🦄 or say *hi* on [Twitter]
 - [usb](https://github.com/nonolith/node-usb) - USB library.
 - [cylon.js](http://cylonjs.com) - Next generation robotics framework with support for 26 different platforms.
 - [i2c-bus](https://github.com/fivdi/i2c-bus) - I2C serial bus access.
+- [pigpio](https://github.com/fivdi/pigpio) - Fast GPIO, PWM, servo control, state change notification and interrupt handling on the Raspberry Pi.
 
 
 ### Templating


### PR DESCRIPTION
[pigpio](https://github.com/fivdi/pigpio) makes things possible on the Raspberry Pi that are typically not possible, for example, PWM and Servo pulses on any number of GPIOs simultaneously.