### PR TITLE
Update MySQL driver URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -586,7 +586,7 @@ Just type [`node.cool`](https://node.cool) to go here ✨
 	- [PostgreSQL](https://github.com/brianc/node-postgres) - PostgreSQL client. Pure JavaScript and native libpq bindings.
 	- [Redis](https://github.com/luin/ioredis) - Redis client.
 	- [LevelUP](https://github.com/Level/levelup) - LevelDB.
-	- [MySQL](https://github.com/felixge/node-mysql) - MySQL client.
+	- [MySQL](https://github.com/mysqljs/mysql) - MySQL client.
 	- [nano](https://github.com/dscape/nano) - CouchDB client.
 	- [Aerospike](https://github.com/aerospike/aerospike-client-nodejs) - Aerospike client.
 	- [Couchbase](https://github.com/couchbase/couchnode) - Couchbase client.


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆

Just updating the MySQL client link from https://github.com/felixge/node-mysql to https://github.com/mysqljs/mysql (GitHub already does this redirect)