### PR TITLE
Add commandir to filesystem section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -379,6 +379,7 @@ Just type [`node.cool`](https://node.cool) to go here ✨
 - [pkg-dir](https://github.com/sindresorhus/pkg-dir) - Find the root directory of an npm package.
 - [sander](https://github.com/rich-harris/sander) - Promise-based replacement for the `fs` module.
 - [filehound](https://github.com/nspragg/filehound) - Flexible and fluent interface for searching the file system.
+- [commandir](https://github.com/fvgs/commandir) - Mkdir and rmdir that are responsible, idempotent, promise based, and a delight to use.
 
 
 ### Control flow


### PR DESCRIPTION
[commandir](https://github.com/fvgs/commandir) is a library offering `mkdir` and `rmdir` functions with the following features:
- Promise based
- Idempotent
- `mkdir` is recursive
- They encourage good software design and error handling by communicating exactly which directories were created or deleted, allowing for proper cleanup in the event the program aborts later on.

Other modules offer the first three features, but I am not aware of any modules offering the final feature.

I came across the need for this implementation when I noticed a program I wrote could possibly encounter an error before completing and leave an empty directory (which was going to be populated) on the user's filesystem. That's just not a nice thing to do.