### PR TITLE
Add nodejs-api-starter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -913,6 +913,7 @@ Just type [`node.cool`](https://node.cool) to go here ✨
 
 - [nodebots](http://nodebots.io) - Robots powered by JavaScript.
 - [node-module-boilerplate](https://github.com/sindresorhus/node-module-boilerplate) - Boilerplate to kickstart creating a node module.
+- [nodejs-api-starter](https://github.com/kriasoft/nodejs-api-starter) - Boilerplate for creating API backends with Docker, Node.js, Redis, PostgreSQL and GraphQL
 - [generator-nm](https://github.com/sindresorhus/generator-nm) - Scaffold out a node module.
 - [awesome-cross-platform-nodejs](https://github.com/bcoe/awesome-cross-platform-nodejs) - Resources for writing and testing cross-platform code.
 - [Microsoft Node.js Guidelines](https://github.com/Microsoft/nodejs-guidelines) - Tips, tricks, and resources for working with Node.js on Microsoft platforms.


### PR DESCRIPTION
**Problem**: How to build a (GraphQL) **data API** on **Node.js** stack? There are many, sometimes contradictory, code samples on the Internet, but putting all the pieces of the puzzle together is tricky (Babel, GraphQL, DataLoader, Passport.js, Docker, transactional email etc.). Is there an end-to-end API example?

**Solution**: Use **[nodejs-api-starter](https://github.com/kriasoft/nodejs-api-starter)** either as a reference or a seed project (boilerplate) for bootstrapping a new Node.js API service. This is a generic solution that will work great with any type of client-side apps (React, React Native, Vue.js, Preact etc.)

![image](https://user-images.githubusercontent.com/197134/27854992-7901ac4a-6171-11e7-815b-915f0635015c.png)

It comes with User, Story, Comment entities (as an example) mimicking the Hacker News API:

<p align="center"><a href="https://graphql-demo.kriasoft.com"><img src="http://koistya.github.io/files/nodejs-api-starter-demo.png" width="600" alt="GraphQL Demo" /><br><sup>https://graphql-demo.kriasoft.com</sup></a></p>

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better.**
