### PR TITLE
Add gradient-string

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -285,7 +285,7 @@ Just type [`node.cool`](https://node.cool) to go here ✨
 - [yargs](https://github.com/yargs/yargs) - Command-line parser that automatically generates an elegant user-interface.
 - [DraftLog](https://github.com/ivanseidel/node-draftlog) - Create multiple updatable log lines. Works just like `console.log`.
 - [Bit](https://github.com/teambit/bit) - Create, maintain, find and use small modules and components across repositories.
-- [gradient-string](https://github.com/bokub/gradient-string) - Beautiful gradients in terminal stdout.
+- [gradient-string](https://github.com/bokub/gradient-string) - Beautiful color gradients in terminal output.
 
 
 ### Build tools

--- a/readme.md
+++ b/readme.md
@@ -285,6 +285,7 @@ Just type [`node.cool`](https://node.cool) to go here ✨
 - [yargs](https://github.com/yargs/yargs) - Command-line parser that automatically generates an elegant user-interface.
 - [DraftLog](https://github.com/ivanseidel/node-draftlog) - Create multiple updatable log lines. Works just like `console.log`.
 - [Bit](https://github.com/teambit/bit) - Create, maintain, find and use small modules and components across repositories.
+- [gradient-string](https://github.com/bokub/gradient-string) - Beautiful gradients in terminal stdout.
 
 
 ### Build tools


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it.**


[gradient-string](https://github.com/bokub/gradient-string) is a package allowing to display colorful strings in the terminal stdout. However, unlike other packages such as chalk, `gradient-string` is focused on __gradients only__ (and actually uses chalk to color each letter individually).

As far as I know, gradient-string is the only package allowing to color stdout with gradients, making it unique and awesome.

[![gradient-string](http://bit.ly/2tlmSgL)](http://bit.ly/2tlhNFv)
