### PR TITLE
Remove deprecated module `nar`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -802,7 +802,6 @@ Just type [`node.cool`](https://node.cool) to go here ✨
 - [dotenv](https://github.com/motdotla/dotenv) - Load environment variables from .env file.
 - [remote-git-tags](https://github.com/sindresorhus/remote-git-tags) - Get tags from a remote git repo.
 - [semver](https://github.com/npm/node-semver) - [semver](http://semver.org) parser.
-- [nar](https://github.com/h2non/nar) - Create self-contained executable binaries.
 - [Faker.js](https://github.com/Marak/Faker.js) - Generate massive amounts of fake data.
 - [nodegit](https://github.com/nodegit/nodegit) - Native bindings to Git.
 - [json-strictify](https://github.com/pigulla/json-strictify) - Safely serialize a value to JSON without data loss or going into an infinite loop.


### PR DESCRIPTION
The `nar` module is deprecated and suggests the `pkg` module which is already in the list.