### PR TITLE
Added clean-mark into Miscellaneous

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -816,6 +816,7 @@ Just type [`node.cool`](https://node.cool) to go here ✨
 - [simplecrawler](https://github.com/cgiffard/node-simplecrawler) - Event driven web crawler.
 - [jsdom](https://github.com/tmpvar/jsdom) - JavaScript implementation of HTML and the DOM.
 - [hypernova](https://github.com/airbnb/hypernova) - Server-side rendering your JavaScript views.
+- [clean-mark](https://github.com/croqaz/clean-mark) - Converts a blog article into a clean Markdown, or text file.
 
 
 ## Resources


### PR DESCRIPTION
Clean-mark converts a blog article into a clean Markdown, or text file.
I haven't seen another tool to do something similar, I find it really useful.

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
