### PR TITLE
Add svg-term-cli

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -286,7 +286,7 @@ Just type [`node.cool`](https://node.cool) to go here ✨
 - [DraftLog](https://github.com/ivanseidel/node-draftlog) - Create multiple updatable log lines. Works just like `console.log`.
 - [Bit](https://github.com/teambit/bit) - Create, maintain, find and use small modules and components across repositories.
 - [gradient-string](https://github.com/bokub/gradient-string) - Beautiful color gradients in terminal output.
-
+- [svg-term-cli](https://github.com/marionebl/svg-term-cli) - Share terminal sessions via SVG and CSS.
 
 ### Build tools
 

--- a/readme.md
+++ b/readme.md
@@ -177,6 +177,7 @@ Just type [`node.cool`](https://node.cool) to go here ✨
 - [lessmd](https://github.com/linuxenko/lessmd) - Markdown in the terminal.
 - [cost-of-modules](https://github.com/siddharthkp/cost-of-modules) - Find out which dependencies are slowing you down.
 - [localtunnel](https://github.com/localtunnel/localtunnel) - Expose your localhost to the world.
+- [svg-term-cli](https://github.com/marionebl/svg-term-cli) - Share terminal sessions via SVG.
 
 
 ### Functional programming
@@ -286,7 +287,7 @@ Just type [`node.cool`](https://node.cool) to go here ✨
 - [DraftLog](https://github.com/ivanseidel/node-draftlog) - Create multiple updatable log lines. Works just like `console.log`.
 - [Bit](https://github.com/teambit/bit) - Create, maintain, find and use small modules and components across repositories.
 - [gradient-string](https://github.com/bokub/gradient-string) - Beautiful color gradients in terminal output.
-- [svg-term-cli](https://github.com/marionebl/svg-term-cli) - Share terminal sessions via SVG and CSS.
+
 
 ### Build tools
 


### PR DESCRIPTION
`svg-term-cli` is a tool to generate SVGs of terminal sessions recorded via `asciinema`. 

The files are animated via CSS, so the animation plays where JavaScript delivery is not possible, such as NPM or GitHub markdown renderings. 


* Reference: https://github.com/sindresorhus/ora/pull/66#issuecomment-354452180
