### PR TITLE
Add node-jsonwebtoken

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -817,6 +817,7 @@ Just type [`node.cool`](https://node.cool) to go here ✨
 - [simplecrawler](https://github.com/cgiffard/node-simplecrawler) - Event driven web crawler.
 - [jsdom](https://github.com/tmpvar/jsdom) - JavaScript implementation of HTML and the DOM.
 - [hypernova](https://github.com/airbnb/hypernova) - Server-side rendering your JavaScript views.
+- [node-jsonwebtoken](https://github.com/auth0/node-jsonwebtoken) - Implementation of JSON Web Token.
 
 
 ## Resources


### PR DESCRIPTION
An implementation of the JSON Web Token standard for Node.
JWTs can be used in almost any scenario where stateless tokens fit in well.

Added to the miscellaneous section of packages. 

https://github.com/auth0/node-jsonwebtoken
