### PR TITLE
add oclif

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -288,6 +288,7 @@ Just type [`node.cool`](https://node.cool) to go here ✨
 - [DraftLog](https://github.com/ivanseidel/node-draftlog) - Create multiple updatable log lines. Works just like `console.log`.
 - [Bit](https://github.com/teambit/bit) - Create, maintain, find and use small modules and components across repositories.
 - [gradient-string](https://github.com/bokub/gradient-string) - Beautiful color gradients in terminal output.
+- [oclif](https://github.com/oclif/oclif) - CLI framework complete with parser, automatic documentation, testing, and plugins.
 
 
 ### Build tools


### PR DESCRIPTION
This is a project that's been in heavy development for a few years and backs both the Salesforce CLI and Heroku CLI. We recently completed the transition to make it usable by others as a generic framework.