### PR TITLE
Add wily-cli to "Command-line utilities"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -288,6 +288,7 @@ Just type [`node.cool`](https://node.cool) to go here ✨
 - [DraftLog](https://github.com/ivanseidel/node-draftlog) - Create multiple updatable log lines. Works just like `console.log`.
 - [Bit](https://github.com/teambit/bit) - Create, maintain, find and use small modules and components across repositories.
 - [gradient-string](https://github.com/bokub/gradient-string) - Beautiful color gradients in terminal output.
+- [wily-cli](https://gitlab.com/jsonsonson/wily-cli) - All-in-one and easy to use command-line parser tool.
 
 
 ### Build tools


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆

Repository: https://gitlab.com/jsonsonson/wily-cli
NPM: https://www.npmjs.com/package/wily-cli

I developed and published wily-cli with the intention of providing a more powerful and easier to use CLI creator tool than the existing tools out there, because I noticed tools like commander and yargs were complicated when trying to create large "git style" CLI projects.

Wily CLI provides more customization, an easy process of setting up sub commands, automated help output, and the ability to create CLI tools in on average lesser lines of code than yargs and commander. One big difference between wily-cli and yargs/commander is that it provides built-in support for both interactive and non-interactive CLIs. An example for both styles are provided in the `examples` folder in the repository.