### PR TITLE
Rename credential-plus to upash

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -649,7 +649,7 @@ Just type [`node.cool`](https://node.cool) to go here ✨
 - [snyk](https://github.com/Snyk/snyk) - CLI and build-time tool to find & fix vulnerable npm dependencies.
 - [nsp](https://github.com/nodesecurity/nsp) - CLI tool to identify known vulnerabilities in your project.
 - [RegEx-DoS](https://github.com/jagracey/RegEx-DoS) - CLI tool to identify possible regex denial of service (ReDos) vulnerabilities in your project.
-- [credential-plus](https://github.com/simonepri/credential-plus) - Password hashing and verification made easy.
+- [upash](https://github.com/simonepri/upash) - Unified APIs for all Password Hashing Algorithms.
 
 
 ### Benchmarking

--- a/readme.md
+++ b/readme.md
@@ -649,7 +649,7 @@ Just type [`node.cool`](https://node.cool) to go here ✨
 - [snyk](https://github.com/Snyk/snyk) - CLI and build-time tool to find & fix vulnerable npm dependencies.
 - [nsp](https://github.com/nodesecurity/nsp) - CLI tool to identify known vulnerabilities in your project.
 - [RegEx-DoS](https://github.com/jagracey/RegEx-DoS) - CLI tool to identify possible regex denial of service (ReDos) vulnerabilities in your project.
-- [upash](https://github.com/simonepri/upash) - Unified APIs for all Password Hashing Algorithms.
+- [upash](https://github.com/simonepri/upash) - Unified API for all password hashing algorithms.
 
 
 ### Benchmarking


### PR DESCRIPTION
I've followed @sindresorhus suggestion in https://github.com/sindresorhus/awesome-nodejs/pull/730
and I've refactored `credential-plus` and renamed it to `upash`.

Project page:
https://github.com/simonepri/upash

This PR updates the name, the url and the description inside the list.