### PR TITLE
Add rsmq

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -691,6 +691,7 @@ Just type [`node.cool`](https://node.cool) to go here ✨
 - [agenda](https://github.com/rschmukler/agenda) - Lightweight job scheduling on MongoDB.
 - [idoit](https://github.com/nodeca/idoit) - Redis-backed job queue engine with advanced job control.
 - [node-resque](https://github.com/taskrabbit/node-resque) - Redis-backed job queue.
+- [rsmq](https://github.com/smrchy/rsmq) - Redis Simple Message Queue
 
 
 ### Node.js management

--- a/readme.md
+++ b/readme.md
@@ -686,12 +686,12 @@ Just type [`node.cool`](https://node.cool) to go here ✨
 
 ### Job queues
 
-- [kue](https://github.com/Automattic/kue) - Priority job queue backed by Redis.
+- [kue](https://github.com/Automattic/kue) - Redis-backed priority job queue.
 - [bull](https://github.com/OptimalBits/bull) - Persistent job and message queue.
-- [agenda](https://github.com/rschmukler/agenda) - Lightweight job scheduling on MongoDB.
+- [agenda](https://github.com/rschmukler/agenda) - MonoDB-backed job scheduling.
 - [idoit](https://github.com/nodeca/idoit) - Redis-backed job queue engine with advanced job control.
 - [node-resque](https://github.com/taskrabbit/node-resque) - Redis-backed job queue.
-- [rsmq](https://github.com/smrchy/rsmq) - Redis Simple Message Queue
+- [rsmq](https://github.com/smrchy/rsmq) - Redis-backed message queue.
 
 
 ### Node.js management


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆

Repo: https://github.com/smrchy/rsmq

From the doc:
> tl;dr: If you run a Redis server and currently use Amazon SQS or a similar message queue you might as well use this fast little replacement. Using a shared Redis server multiple Node.js processes can send / receive messages.