### PR TITLE
Add fastify Node.js server

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -353,6 +353,7 @@ Just type [`node.cool`](https://node.cool) to go here ✨
 - [AdonisJs](http://adonisjs.com) - A true MVC framework for Node.js built on solid foundations of Dependency Injection and IoC container.
 - [Hemera](https://github.com/hemerajs/hemera) - Write reliable and fault-tolerant microservices with [NATS](https://nats.io).
 - [Micro](https://github.com/zeit/micro) - Minimalistic microservice framework with an async approach.
+- [Fastify](https://github.com/fastify/fastify) - Ludicrously fast and low overhead web framework.
 
 
 ### Documentation


### PR DESCRIPTION
[Link to project](https://github.com/fastify/fastify)

Fastify is blazing fast Node.js server, and it beats the competition in ["hello world" benchmark](https://github.com/fastify/fastify#benchmarks) that aims to evaluate the framework overhead

Additional information:
* [Reaching ludicrous speed with Fastify](https://www.nearform.com/blog/reaching-ludicrous-speed-with-fastify/)
* [Ecosystem](https://www.fastify.io/ecosystem/)
* [Benchmarks](https://www.fastify.io/benchmarks/)