### PR TITLE
gitlink-cli - opens current repo|commit in default browser (github|gitlab|bitbucket)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -125,7 +125,6 @@
 - [npm-name](https://github.com/sindresorhus/npm-name) - Check whether a package name is available on npm.
 - [gh-home](https://github.com/sindresorhus/gh-home) - Open the GitHub page of the repo in the current directory.
 - [npm-home](https://github.com/sindresorhus/npm-home) - Open the npm page of a package.
-- [gitlink-cli](https://github.com/bitbonsai/gitlink-cli) - Open the github|gitlab|bitbucket repo|commit page in default browser
 - [trash](https://github.com/sindresorhus/trash) - Safer alternative to `rm`.
 - [speed-test](https://github.com/sindresorhus/speed-test) - Test your internet connection speed and ping.
 - [emoj](https://github.com/sindresorhus/emoj) - Find relevant emoji from text on the command-line.
@@ -177,7 +176,7 @@
 - [svg-term-cli](https://github.com/marionebl/svg-term-cli) - Share terminal sessions via SVG.
 - [gtop](https://github.com/aksakalli/gtop) - System monitoring dashboard for the terminal.
 - [themer](https://github.com/mjswensen/themer) - Generate themes for your editor, terminal, wallpaper, Slack, and more.
-
+- [gitlink-cli](https://github.com/bitbonsai/gitlink-cli) - Open the github|gitlab|bitbucket repo|commit page in default browser.
 
 ### Functional programming
 

--- a/readme.md
+++ b/readme.md
@@ -125,6 +125,7 @@
 - [npm-name](https://github.com/sindresorhus/npm-name) - Check whether a package name is available on npm.
 - [gh-home](https://github.com/sindresorhus/gh-home) - Open the GitHub page of the repo in the current directory.
 - [npm-home](https://github.com/sindresorhus/npm-home) - Open the npm page of a package.
+- [gitlink-cli](https://github.com/bitbonsai/gitlink-cli) - Open the github|gitlab|bitbucket repo|commit page in default browser
 - [trash](https://github.com/sindresorhus/trash) - Safer alternative to `rm`.
 - [speed-test](https://github.com/sindresorhus/speed-test) - Test your internet connection speed and ping.
 - [emoj](https://github.com/sindresorhus/emoj) - Find relevant emoji from text on the command-line.


### PR DESCRIPTION
https://github.com/bitbonsai/gitlink-cli

A small and super useful cli tool, that opens the default browser with the current repository page (that it gets from `git remote -v`).

## Usecase
You're in the terminal, wants to open the repository page in the browser, just type `gitlink` and it will open in the default browser. Works for github, gitlab and bitbucket, and if a partial `sha1` is provided will open the specific commit page.

If user is on a remote terminal (ssh) will just **print** the link (also available with option --print).