### PR TITLE
add snekfetch http client

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -203,6 +203,7 @@
 - [superagent](https://github.com/visionmedia/superagent) - HTTP request library.
 - [node-fetch](https://github.com/bitinn/node-fetch) - `window.fetch` for Node.js.
 - [flashheart](https://github.com/bbc/flashheart) - REST client.
+- [snekfetch](https://github.com/devsnek/snekfetch) - Fast, efficient, and user-friendly HTTP requests.
 - [http-fake-backend](https://github.com/micromata/http-fake-backend) - Build a fake backend by providing the content of JSON files or JavaScript objects through configurable routes.
 - [cacheable-request](https://github.com/lukechilds/cacheable-request) - Wrap native HTTP requests with RFC compliant cache support.
 - [gotql](https://github.com/khaosdoctor/gotql) - GraphQL request library built on [got](https://github.com/sindresorhus/got).


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆

[devsnek/snekfetch](https://github.com/devsnek/snekfetch)

One of the first HTTP clients that use http2 for requests