### PR TITLE
Add Cliffy

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -252,7 +252,6 @@
 - [string-width](https://github.com/sindresorhus/string-width) - Get the visual width of a string - the number of columns required to display it.
 - [cli-truncate](https://github.com/sindresorhus/cli-truncate) - Truncate a string to a specific width in the terminal.
 - [first-run](https://github.com/sindresorhus/first-run) - Check if it's the first time the process is run.
-- [vorpal](https://github.com/dthree/vorpal) - Interactive CLI apps.
 - [blessed](https://github.com/chjj/blessed) - Curses-like library.
 - [Inquirer.js](https://github.com/SBoudrias/Inquirer.js) - Interactive command-line prompt.
 - [yn](https://github.com/sindresorhus/yn) - Parse yes/no like values.
@@ -277,7 +276,7 @@
 - [gradient-string](https://github.com/bokub/gradient-string) - Beautiful color gradients in terminal output.
 - [oclif](https://github.com/oclif/oclif) - CLI framework complete with parser, automatic documentation, testing, and plugins.
 - [term-size](https://github.com/sindresorhus/term-size) - Reliably get the terminal window size.
-- [Cliffy](https://github.com/drew-y/cliffy) - Framework for interactive CLIs, an alternative to Vorpal.
+- [Cliffy](https://github.com/drew-y/cliffy) - Framework for interactive CLIs.
 
 
 ### Build tools

--- a/readme.md
+++ b/readme.md
@@ -277,6 +277,7 @@
 - [gradient-string](https://github.com/bokub/gradient-string) - Beautiful color gradients in terminal output.
 - [oclif](https://github.com/oclif/oclif) - CLI framework complete with parser, automatic documentation, testing, and plugins.
 - [term-size](https://github.com/sindresorhus/term-size) - Reliably get the terminal window size.
+- [Cliffy](https://github.com/drew-y/cliffy) - Framework for interactive CLIs, an alternative to Vorpal.
 
 
 ### Build tools


### PR DESCRIPTION
This requests adds [Cliffy](https://github.com/drew-y/cliffy) to the Command-line utilities section.

[Cliffy](https://github.com/drew-y/cliffy) is an alternative to [Vorpal](https://github.com/dthree/vorpal).

Compared with Vorpal, Cliffy provides:
- Active Maintenance (Vorpal's last release was in 2015)
- Can parse negative numbers as parameters
- Typed parameters
- Typescript support
- Custom input / output streams  