### PR TITLE
Adds carbon-now-cli

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -176,6 +176,7 @@
 - [svg-term-cli](https://github.com/marionebl/svg-term-cli) - Share terminal sessions via SVG.
 - [gtop](https://github.com/aksakalli/gtop) - System monitoring dashboard for the terminal.
 - [themer](https://github.com/mjswensen/themer) - Generate themes for your editor, terminal, wallpaper, Slack, and more.
+- [carbon-now-cli](https://github.com/mixn/carbon-now-cli) - Beautiful images of your code — from right inside your terminal.
 
 
 ### Functional programming


### PR DESCRIPTION
**[carbon-now-cli](https://github.com/mixn/carbon-now-cli) — 🎨 Beautiful images of your code — from right inside your terminal.**

**Why it should be included**:

It serves as a handy & fast wrapper for [https://carbon.now.sh/](https://carbon.now.sh/) while adding extra features like selective highlighting, presets, an interactive mode and much more. :)

**Re: contribution guidelines**:

- Wait 30 days ✅ 
- Search previous suggestions before making a new one (extensively) ✅ 
- Tested and documented ✅ 
- Individual PR ✅ 
- Follows `[package](link) - Description.` format ✅ 
- Adds itself to the bottom of the category ✅ 
- Links to Github repo ✅ 
- Short & descriptive ✅ 
- Doesn’t mention Node.js ✅ 
- Starts with capital and ends with . ✅ 
- Doesn’t start with A/An ✅ 
- Checked spelling and grammar multiple times ✅ 
- Made sure editor removes trailing whitespace ✅ 

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
