### PR TITLE
add nodejs/llnode

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -229,6 +229,7 @@
 - [0x](https://github.com/davidmarkclements/0x) - Flamegraph profiling.
 - [ctrace](https://github.com/automation-stack/ctrace) - Well-formatted and improved trace system calls and signals.
 - [leakage](https://github.com/andywer/leakage) - Write memory leak tests.
+- [llnode](https://github.com/nodejs/llnode) - Post-mortem analysis tool which allows you to inspect objects and get insights from a crashed Node.js process.
 
 
 ### Logging


### PR DESCRIPTION
### llnode — Post-mortem analysis tool which allows you to inspect objects and get insights from a crashed Node.js process.

#### Why it should be included

`llnode` is a post-mortem debugger which can be used to read core dumps generated from crash processes. The user can inspect objects, get insights on the heap usage and inspect context of functions in the call stack after their process crashed. It is one of the few tools capable of doing proper post-mortem analysis in the ecosystem, and is the only one kept up-to-date with Node.js releases (the other tool is mdb_v8).

#### Checklist

  - [x] Wait 30 days
  - [x] Search previous suggestions before making a new one (extensively)
  - [x] Tested and documented
  - [x] Individual PR
  - [x] Follows `[package](link) - Description.` format
  - [x] Adds itself to the bottom of the category
  - [x] Links to Github repo
  - [x] Short & descriptive
  - [x] Starts with capital and ends with .
  - [x] Doesn’t start with A/An
  - [x] Checked spelling and grammar multiple times
  - [x] Made sure editor removes trailing whitespace
  - [ ] Doesn’t mention Node.js ⚠️ 
    - (I think the description for this tool needs to mention Node.js, but I can try to reword it to remove the mention if you want).


**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
