### PR TITLE
Add discharge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -183,7 +183,7 @@
 - [gtop](https://github.com/aksakalli/gtop) - System monitoring dashboard for the terminal.
 - [themer](https://github.com/mjswensen/themer) - Generate themes for your editor, terminal, wallpaper, Slack, and more.
 - [carbon-now-cli](https://github.com/mixn/carbon-now-cli) - Beautiful images of your code — from right inside your terminal.
-- [Discharge](https://github.com/brandonweiss/discharge) - Simple, easy way to deploy static websites to Amazon S3.
+- [Discharge](https://github.com/brandonweiss/discharge) - Easily deploy static websites to Amazon S3.
 
 
 ### Functional programming

--- a/readme.md
+++ b/readme.md
@@ -184,7 +184,7 @@
 - [carbon-now-cli](https://github.com/mixn/carbon-now-cli) - Beautiful images of your code — from right inside your terminal.
 - [cash-cli](https://github.com/xxczaki/cash-cli) - Convert between 170 currencies.
 - [taskbook](https://github.com/klauscfhq/taskbook) - Tasks, boards & notes for the command-line habitat.
-- [Discharge](https://github.com/brandonweiss/discharge) - Easily deploy static websites to Amazon S3.
+- [discharge](https://github.com/brandonweiss/discharge) - Easily deploy static websites to Amazon S3.
 
 
 ### Functional programming

--- a/readme.md
+++ b/readme.md
@@ -183,6 +183,7 @@
 - [gtop](https://github.com/aksakalli/gtop) - System monitoring dashboard for the terminal.
 - [themer](https://github.com/mjswensen/themer) - Generate themes for your editor, terminal, wallpaper, Slack, and more.
 - [carbon-now-cli](https://github.com/mixn/carbon-now-cli) - Beautiful images of your code — from right inside your terminal.
+- [Discharge](https://github.com/brandonweiss/discharge) - Simple, easy way to deploy static websites to Amazon S3.
 
 
 ### Functional programming


### PR DESCRIPTION
[Discharge](https://github.com/brandonweiss/discharge) is, as far as I’m aware, the easiest way to deploy static websites to Amazon S3. It can also configure an SSL certificate and distribute the site via CloudFront, all without having to know anything about AWS. I spent hours poring over AWS’s terrible docs so no one else would have to. There is also a prompt-based UI to help you configure it. And it’s very well documented.

Thanks for considering!

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
