### PR TITLE
Remove `Podcasts` from TOC as it doesn't exist

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,6 @@
 	- [Articles](#articles)
 	- [Newsletters](#newsletters)
 	- [Videos](#videos)
-	- [Podcasts](#podcasts)
 	- [Books](#books)
 	- [Blogs](#blogs)
 	- [Courses](#courses)


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆

I clicked on Podcasts section of Resources and it was just hyperlinked and going nowhere, it can be added back if someone wants to add links related to podcasts.

