### PR TITLE
Add 'MagiCLI' lib

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -284,6 +284,7 @@
 - [gradient-string](https://github.com/bokub/gradient-string) - Beautiful color gradients in terminal output.
 - [oclif](https://github.com/oclif/oclif) - CLI framework complete with parser, automatic documentation, testing, and plugins.
 - [term-size](https://github.com/sindresorhus/term-size) - Reliably get the terminal window size.
+- [magicli](https://github.com/DiegoZoracKy/magicli) - Automagically generates command-line interfaces for any module, or, execute any module via CLI.
 
 
 ### Build tools


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆

The goal of [MagiCLI](https://github.com/DiegoZoracKy/magicli) is to automagically generate a command-line interface for any module, without the need to create anything by hand. Just `require('magicli')();` and your module is ready to be executed via CLI. It is also capable of executing any module via CLI, even if the target module doesn't provide one. Just install it globally (or use *npx*) and: `$ magicli ./path/to-a-module-file-or-package.js --help`.

Articles written about it:

[Introducing MagiCLI: Automagically generates a command-line interface (CLI) for any module
](https://hackernoon.com/introducing-magicli-automagically-generates-a-command-line-interface-cli-for-any-module-49543e50f86d)

[Executing any Node.js module or .js file via CLI without creating any command-line interface at all
](https://hackernoon.com/executing-any-node-js-module-or-js-file-via-cli-without-creating-any-command-line-interface-at-all-6f3a125fdf5a)

![1_3mw1jcvfq2ijhxmnd6di9q](https://user-images.githubusercontent.com/2091071/46184544-7a7d5e00-c2ac-11e8-8d82-cc57c2489463.gif)


