### PR TITLE
Add Squirrelly to the Templating section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -323,6 +323,7 @@
 - [handlebars.js](https://github.com/wycats/handlebars.js) - Superset of Mustache templates which adds powerful features like helpers and more advanced blocks.
 - [EJS](https://github.com/mde/ejs) - Simple unopinionated templating language.
 - [Pug](https://github.com/pugjs/pug) - High-performance template engine heavily influenced by Haml.
+- [Squirrelly](https://github.com/nebrelbug/squirrelly) - Blazing fast and lightweight template engine that supports partials, helpers, custom tags, and isn't whitespace sensitive.
 
 
 ### Web frameworks


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆

Why Squirrelly?
- It's more lightweight than any of the engines on the list
- It's faster than any of the template engines on the list: https://github.com/nebrelbug/squirrelly-benchmarks
- It supports partials, custom tags, caching, native code, helpers, helper blocks

Thank you!
