### PR TITLE
Added OWASP ZAP Node API

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -634,6 +634,7 @@
 - [snyk](https://github.com/Snyk/snyk) - CLI and build-time tool to find & fix vulnerable npm dependencies.
 - [upash](https://github.com/simonepri/upash) - Unified API for all password hashing algorithms.
 - [themis](https://github.com/cossacklabs/themis) - Multilanguage framework for making typical encryption schemes easy to use: data at rest, authenticated data exchange, transport protection, authentication, and so on.
+- [zaproxy](https://github.com/zaproxy/zap-api-nodejs) - OWASP ZAP API: Established and officially maintained API for consuming ZAP, useful for security regression testing.
 
 
 ### Benchmarking


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆

The OWASP ZAP Node API is consumed by many projects, mainly used for security regression testing. The API has been unmaintained for a few years, but is now updated with [new features](https://github.com/zaproxy/zap-api-nodejs/blob/master/CHANGELOG.md), in a new repository, now on the  [official API list](https://github.com/zaproxy/zaproxy/wiki/ApiDetails).

Release [tweet](https://twitter.com/zaproxy/status/1063378335928131585)

The main [issue](https://github.com/zaproxy/zaproxy/issues/5044) and [PR](https://github.com/zaproxy/zap-api-nodejs/pull/1).

[Github repos consuming the API](https://github.com/search?q=filename%3Apackage.json+zaproxy)
