### PR TITLE
Added mailgun-mate

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -669,6 +669,7 @@
 - [Nodemailer](https://github.com/andris9/Nodemailer) - The fastest way to handle email.
 - [emailjs](https://github.com/eleith/emailjs) - Send text/HTML emails with attachments to any SMTP server.
 - [email-templates](https://github.com/niftylettuce/email-templates) - Create, preview, and send custom email templates.
+- [mailgun-mate](https://github.com/binarymist/mailgun-mate) - CLI to interface with the MailGun API for scheduling batches of custom HTML emails.
 
 
 ### Job queues


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆

Tool created out of my own (consultant) dissatisfaction with the lack of flexibility with the free email services, and some paid ones. Mailgun is a very powerful API for scheduling, and managing batches of emails. It's just an API though, so I built a CLI for it. Mailgun is free for up to 10,000 email sends per month, which is more than enough for most people and small companies.

Simply sign up for a free Mailgun account, create your HTML email, point mailgun-mate to it, and fill in the rest of the details in the CLI or it's config file, select your recipients from an ordered list, and apply various optional tags.

The CLI shows you when the last emails were sent for any given recipient.

I use this tool weekly for my own business and for organising conferences

