### PR TITLE
Add GuardRails GitHub app to Security

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -634,6 +634,7 @@
 - [snyk](https://github.com/Snyk/snyk) - CLI and build-time tool to find & fix vulnerable npm dependencies.
 - [upash](https://github.com/simonepri/upash) - Unified API for all password hashing algorithms.
 - [themis](https://github.com/cossacklabs/themis) - Multilanguage framework for making typical encryption schemes easy to use: data at rest, authenticated data exchange, transport protection, authentication, and so on.
+- [GuardRails](https://github.com/apps/guardrails) - A GitHub App that provides security feedback in Pull Requests.
 
 
 ### Benchmarking


### PR DESCRIPTION
Nice list @sindresorhus, 

I've created a pr that adds the GuardRails GitHub application to the Security section.
