### PR TITLE
Add fs-mktemp

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -381,6 +381,7 @@
 - [pkg-dir](https://github.com/sindresorhus/pkg-dir) - Find the root directory of an npm package.
 - [filehound](https://github.com/nspragg/filehound) - Flexible and fluent interface for searching the file system.
 - [move-file](https://github.com/sindresorhus/move-file) - Move a file, even works across devices.
+- [fs-mktemp](https://github.com/honzahommer/node-fs-mktemp) - Create temporary file or directory, like `mktemp`.
 
 
 ### Control flow


### PR DESCRIPTION
[fs-mktemp](https://github.com/honzahommer/node-fs-mktemp) helps to create temporary file or directory, like `mktemp`.

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
