### PR TITLE
Add play-sound

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -815,6 +815,7 @@
 - [emittery](https://github.com/sindresorhus/emittery) - Simple and modern async event emitter.
 - [node-video-lib](https://github.com/gkozlenko/node-video-lib) - Pure JavaScript library for working with MP4 and FLV video files and creating MPEG-TS chunks for HLS streaming.
 - [basic-ftp](https://github.com/patrickjuchli/basic-ftp) – FTP/FTPS client.
+- [play-sound](https://github.com/shime/play-sound) - Play audio files using one of the available players.
 
 
 ## Resources


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆

https://github.com/shime/play-sound

It doesn't provide fallback binaries (probably because those can be pretty bulky), but otherwise it is similar to [clipboardy](https://github.com/sindresorhus/clipboardy), allowing for a simple API, e.g.

```js
play('some.mp3')
```

which will attempt to play it by `spawn`ing an available system player.