### PR TITLE
Added yesql

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -581,6 +581,7 @@
 	- [slonik](https://github.com/gajus/slonik) - PostgreSQL client with strict types, detailed logging and assertions.
 	- [Objection.js](https://github.com/Vincit/objection.js) - Lightweight ORM built on the SQL query builder Knex.
 	- [TypeORM](https://github.com/typeorm/typeorm) - ORM for PostgreSQL, MariaDB, MySQL, SQLite, and more.
+	- [yesql](https://github.com/pihvi/yesql) - Use named parameters in raw SQL queries before submitting to a database
 - Query builder
 	- [Knex](https://github.com/tgriesser/knex) - Query builder for PostgreSQL, MySQL and SQLite3, designed to be flexible, portable, and fun to use.
 - Other


### PR DESCRIPTION
Yesql is pretty useful for using named parameters and for building raw SQL queries by hand before submitting them to node-postgres, for example, instead of using Slonik or Knex.