### PR TITLE
Add JKT and PodengJs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -501,6 +501,7 @@
 - [property-validator](https://github.com/nettofarah/property-validator) - Easy property validation for Express.
 - [schema-inspector](https://github.com/Atinux/schema-inspector) - JSON API sanitization and validation.
 - [ajv](https://github.com/epoberezkin/ajv) - The fastest JSON Schema validator. Supports v5 proposals.
+- [podengjs](https://github.com/slaveofcode/podeng) - Advanced JSON value parser & validator to have consistent result data 
 
 
 ### Parsing
@@ -529,6 +530,8 @@
 - [xlsx-populate](https://github.com/dtjohnson/xlsx-populate) - Read/write Excel XLSX.
 - [Chevrotain](https://github.com/SAP/chevrotain) - Very fast and feature rich parser building toolkit for JavaScript.
 - [fast-xml-parser](https://github.com/NaturalIntelligence/fast-xml-parser) - Validate and parse XML.
+- [jkt](https://github.com/slaveofcode/jkt) - Handy JSON value parser object via text literal
+- [podengjs](https://github.com/slaveofcode/podeng) - Advanced JSON value parser & validator to have consistent result data 
 
 
 ### Humanize

--- a/readme.md
+++ b/readme.md
@@ -501,7 +501,7 @@
 - [property-validator](https://github.com/nettofarah/property-validator) - Easy property validation for Express.
 - [schema-inspector](https://github.com/Atinux/schema-inspector) - JSON API sanitization and validation.
 - [ajv](https://github.com/epoberezkin/ajv) - The fastest JSON Schema validator. Supports v5 proposals.
-- [podengjs](https://github.com/slaveofcode/podeng) - Advanced JSON value parser & validator to have consistent result data 
+- [podengjs](https://github.com/slaveofcode/podeng) - Advanced JSON value parser & validator to have consistent result data.
 
 
 ### Parsing
@@ -530,8 +530,8 @@
 - [xlsx-populate](https://github.com/dtjohnson/xlsx-populate) - Read/write Excel XLSX.
 - [Chevrotain](https://github.com/SAP/chevrotain) - Very fast and feature rich parser building toolkit for JavaScript.
 - [fast-xml-parser](https://github.com/NaturalIntelligence/fast-xml-parser) - Validate and parse XML.
-- [jkt](https://github.com/slaveofcode/jkt) - Handy JSON value parser object via text literal
-- [podengjs](https://github.com/slaveofcode/podeng) - Advanced JSON value parser & validator to have consistent result data 
+- [jkt](https://github.com/slaveofcode/jkt) - Handy JSON parser object via text literal (Golang Struct like structure).
+- [podengjs](https://github.com/slaveofcode/podeng) - Advanced JSON value parser & validator to have consistent result data.
 
 
 ### Humanize


### PR DESCRIPTION
JKT is the one of my project to resolve data structure consistency among our JSON values, and also JKT is acting as a parser on RESTful api response at [usetada.com](https://usetada.com). That library is simply and fast enough to make an object using a string literal (you can even create with one line only), which is what my team needs in order to easy-setup rules on our json objects inside the application.

And then the biggest part is coming, the project on some feature needs a more way to parse with more advanced feature, which is unsupported by JKT. Based on the first problem (which solved by jkt) then I built PodengJs which provide the json parser but also validator (optional, by config). That's why I also put the PodengJs on validator section.

Please just hit me if the purpose of PodengJs here is not matching the criteria of these validator list, I'll just remove and create an update.

Github: 
- https://github.com/slaveofcode/podeng
- https://github.com/slaveofcode/jkt
