### PR TITLE
Add Charge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -739,6 +739,7 @@
 - [DocPad](https://github.com/docpad/docpad) - Static site generator with dynamic abilities and huge plugin ecosystem.
 - [Phenomic](https://github.com/phenomic/phenomic) - Modern static website generator based on the React and Webpack ecosystem.
 - [docsify](https://github.com/QingWei-Li/docsify) - Markdown documentation site generator with no statically built HTML files.
+- [Charge](https://github.com/brandonweiss/charge) - Opinionated, zero-config static site generator using JSX and MDX.
 
 
 ### Content management systems


### PR DESCRIPTION
[Charge](https://charge.js.org) is an opinionated, zero-config static site generator. It uses JSX and MDX for templating. CSS is post-processed with PostCSS. JavaScript is transpiled with Babel. You can import any type of module from npm without having to worry about what format it uses. You don’t have to define “entrypoints” or where dependencies are located—it just figures it all out for you and does the right thing. It hopefully works exactly how you’d expect it to. And last, it doesn’t serve React to the front-end like many popular React-based static site generators, which is usually overkill for small sites.

I didn’t really want to build this. If you’d asked me a while ago, I would have said the last thing the world needs is another static site generator. But when I went hunting for a replacement to the aging [Middleman](https://middlemanapp.com) for my 10+ static sites, I just couldn’t find anything that was even remotely close to what I was looking for. Every tool seemed to have Webpack’s philosophy: infinite flexibility so you can do exactly whatever you want, as opposed to my philosophy: convention over configuration, so I can make my site and then go do literally anything else other than spending hours fiddling with configurations.

I hope you think it’s unique enough to add—thanks for considering!

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
