### PR TITLE
Add nanoid

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -120,6 +120,7 @@
 - [skale](https://github.com/skale-me/skale-engine) - High performance distributed data processing engine.
 - [xlsx](https://github.com/sheetjs/js-xlsx) - Pure JS Excel spreadsheet reader and writer.
 - [isomorphic-git](https://github.com/isomorphic-git/isomorphic-git) - Pure JavaScript implementation of Git.
+- [nanoid](https://github.com/ai/nanoid) - A tiny, secure, URL-friendly, unique string ID generator.
 
 
 ### Command-line apps

--- a/readme.md
+++ b/readme.md
@@ -120,7 +120,6 @@
 - [skale](https://github.com/skale-me/skale-engine) - High performance distributed data processing engine.
 - [xlsx](https://github.com/sheetjs/js-xlsx) - Pure JS Excel spreadsheet reader and writer.
 - [isomorphic-git](https://github.com/isomorphic-git/isomorphic-git) - Pure JavaScript implementation of Git.
-- [nanoid](https://github.com/ai/nanoid) - Tiny, secure, URL-friendly, unique string ID generator.
 
 
 ### Command-line apps
@@ -470,6 +469,7 @@
 - [matcher](https://github.com/sindresorhus/matcher) - Simple wildcard matching.
 - [unhomoglyph](https://github.com/nodeca/unhomoglyph) - Normalize visually similar unicode characters.
 - [i18next](https://github.com/i18next/i18next) - Internationalization framework.
+- [nanoid](https://github.com/ai/nanoid) - Tiny, secure, URL-friendly, unique string ID generator.
 
 
 ### Number

--- a/readme.md
+++ b/readme.md
@@ -120,7 +120,7 @@
 - [skale](https://github.com/skale-me/skale-engine) - High performance distributed data processing engine.
 - [xlsx](https://github.com/sheetjs/js-xlsx) - Pure JS Excel spreadsheet reader and writer.
 - [isomorphic-git](https://github.com/isomorphic-git/isomorphic-git) - Pure JavaScript implementation of Git.
-- [nanoid](https://github.com/ai/nanoid) - A tiny, secure, URL-friendly, unique string ID generator.
+- [nanoid](https://github.com/ai/nanoid) - Tiny, secure, URL-friendly, unique string ID generator.
 
 
 ### Command-line apps


### PR DESCRIPTION
https://github.com/ai/nanoid is an actively maintained id-generator which compares best to UUIDv4 (random-based id generation) which generates ids with a similar collision probability, but less size (21 symbols vs 36) and ~16% faster. It has security in mind (using crypts random number generator and providing a company-backed disclosure procedure.

It is very helpful at any point heavily relying on collision-free ids, like f.e. cassandra or couchdb document-ids.

I don't know if mad science is the best category.

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
