### PR TITLE
Add modern-node

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -921,7 +921,7 @@
 
 - [nodebots](http://nodebots.io) - Robots powered by JavaScript.
 - [node-module-boilerplate](https://github.com/sindresorhus/node-module-boilerplate) - Boilerplate to kickstart creating a node module.
-- [modern-node](https://github.com/sheerun/modern-node) - Toolkit for creating node modules with Jest+Prettier+Eslint+Standard
+- [modern-node](https://github.com/sheerun/modern-node) - Toolkit for creating node modules with Jest, Prettier, ESLint, and Standard.
 - [generator-nm](https://github.com/sindresorhus/generator-nm) - Scaffold out a node module.
 - [Microsoft Node.js Guidelines](https://github.com/Microsoft/nodejs-guidelines) - Tips, tricks, and resources for working with Node.js on Microsoft platforms.
 - [Module Requests & Ideas](https://github.com/sindresorhus/module-requests) - Request a JavaScript module you wish existed or get ideas for modules.

--- a/readme.md
+++ b/readme.md
@@ -921,6 +921,7 @@
 
 - [nodebots](http://nodebots.io) - Robots powered by JavaScript.
 - [node-module-boilerplate](https://github.com/sindresorhus/node-module-boilerplate) - Boilerplate to kickstart creating a node module.
+- [modern-node](https://github.com/sheerun/modern-node) - Toolkit for creating node modules with Jest+Prettier+Eslint+Standard
 - [generator-nm](https://github.com/sindresorhus/generator-nm) - Scaffold out a node module.
 - [Microsoft Node.js Guidelines](https://github.com/Microsoft/nodejs-guidelines) - Tips, tricks, and resources for working with Node.js on Microsoft platforms.
 - [Module Requests & Ideas](https://github.com/sindresorhus/module-requests) - Request a JavaScript module you wish existed or get ideas for modules.


### PR DESCRIPTION
https://github.com/sheerun/modern-node

> For CLI tools, the bar is especially high, and unless it's something very awesome

I think it's awesome through the roof but it's up to you to decide :P

This project is similar just to your boilerplate but works differently:

1. It's not meant for cloning but installing or creating with `create-modern-node`
2. It uses jest instead of ava, it uses prettier+eslint+standard instead of xo
3. It has built in precommit hook so installing husky is not necessary

I've put it next to your package instead of at the bottom because these two are most similar in functionality.
