### PR TITLE
Add swagger-routes-express to Web frameworks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -349,7 +349,7 @@
 - [Nest](https://github.com/nestjs/nest) - Angular-inspired framework for building efficient and scalable server-side apps.
 - [Zeronode](https://github.com/sfast/zeronode) - Minimal building block for reliable and fault-tolerant microservices.
 - [TypeGraphQL](https://github.com/19majkel94/type-graphql) - Modern framework for creating GraphQL APIs with TypeScript, using classes and decorators.
-
+- [swagger-routes-express](https://github.com/davesag/swagger-routes-express) — Connects Express route controllers to restful paths using a Swagger v2 or OpenAPI v3 definition file.
 
 ### Documentation
 


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆

Added [swagger-routes-express](https://github.com/davesag/swagger-routes-express) to Web frameworks.

It's superficially similar to `Restify` but with more of a swagger-first focus.  It's in use by a number of projects now and quite mature.
