### PR TITLE
Remove CloudRail

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -667,7 +667,6 @@
 
 - [Passport](https://github.com/jaredhanson/passport) - Simple, unobtrusive authentication.
 - [Grant](https://github.com/simov/grant) - OAuth middleware for Express, Koa, and Hapi.
-- [CloudRail](https://github.com/CloudRail/cloudrail-si-node-sdk) - Unified API for social authentication (Facebook, Twitter, Slack, Instagram, …).
 
 
 ### Authorization


### PR DESCRIPTION
The CloudRail project has now been discontinued as per their [README](https://github.com/CloudRail/cloudrail-si-node-sdk):

> We decided to discontinue this product as of February 2019. CloudRail now entirely focuses on connecting industrial sensors to AWS, Azure, Google IoT and many more to realize IIoT projects. Learn more at https://cloudrail.com