### PR TITLE
Add nve

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -646,6 +646,7 @@
 - [abstruse](https://github.com/bleenco/abstruse) - Continuous Integration server.
 - [CodeceptJS](https://github.com/Codeception/CodeceptJS) - End-to-end testing.
 - [Puppeteer](https://github.com/GoogleChrome/puppeteer) - Headless Chrome.
+- [nve](https://github.com/ehmicky/nve) - Run any command on multiple versions of Node.js locally.
 
 
 ### Security


### PR DESCRIPTION
`nve` is a tool to run any command using any Node.js version. 

It is like `nvm exec` but improved: it can run multiple Node.js versions at once (either serially or in parallel), works programmatically, does not require a separate installation step, works on Windows, is installed as a Node module (not a Bash script) and is [much faster](https://github.com/ehmicky/nve#benchmarks).

Example: 

```
# Run tests on multiple Node.js versions
nve 8 10 13 npm test
```

Many more examples [here](https://github.com/ehmicky/nve#examples).

Repository: https://github.com/ehmicky/nve

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
