### PR TITLE
Add dclone

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -195,6 +195,7 @@
 - [taskbook](https://github.com/klauscfhq/taskbook) - Tasks, boards & notes for the command-line habitat.
 - [discharge](https://github.com/brandonweiss/discharge) - Easily deploy static websites to Amazon S3.
 - [npkill](https://github.com/voidcosmos/npkill) - Easily find and remove old and heavy node_modules folders.
+- [dclone](https://github.com/ykfe/dclone) - The simplest command for downloading specified directory or whole repo in github/gitlab.
 
 ### Functional programming
 


### PR DESCRIPTION
dclone is the Command-line apps and more information  is dclone is the simplest command for downloading specified directory or whole repo in github/gitlab (used depend on git), dclone can completely replace git clone and cut down download time

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
