### PR TITLE
Adding express-rate-limit middleware for Express

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -615,6 +615,7 @@
 - [rate-limiter-flexible](https://github.com/animir/node-rate-limiter-flexible) - Brute-force and DDoS attack protection.
 - [crypto-hash](https://github.com/sindresorhus/crypto-hash) - Async non-blocking hashing.
 - [jose-simple](https://github.com/davesag/jose-simple) - Encryption and decryption of data using the JOSE (JSON Object Signing and Encryption) standard.
+- [express-rate-limit](https://github.com/nfriedly/express-rate-limit) - API rate-limiting middleware for Express. It Use to limit repeated requests during DDos attack to public APIs.
 
 ### Benchmarking
 


### PR DESCRIPTION
I have followed the contribution guidelines. This package Uses to limit repeated requests during DDoS attacks to public APIs.

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
