### PR TITLE
Add light-date

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -487,6 +487,7 @@
 - [dateformat](https://github.com/felixge/node-dateformat) - Date formatting.
 - [tz-format](https://github.com/samverschueren/tz-format) - Format a date with timezone: `2015-11-30T10:40:35+01:00`.
 - [cctz](https://github.com/floatdrop/node-cctz) - Fast parsing, formatting, and timezone conversation for dates.
+- [light-date](https://github.com/xxczaki/light-date) - Blazing fast and lightweight (157 bytes) date formatting.
 
 ### URL
 


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆

Light Date is a date formatting module, that works in Node.js and the browser. It is super lightweight (157 bytes minified & gzipped, no dependencies) and fast (see the [benchmarks](https://github.com/xxczaki/light-date#benchmarks)). It also follows [Unicode Technical Standard #35](https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table).

**The repo is about 19 days old, so I'm submitting it as a draft PR - will publish it when it reaches 30 days.**