### PR TITLE
Add smoke

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -216,6 +216,7 @@
 - [cacheable-request](https://github.com/lukechilds/cacheable-request) - Wrap native HTTP requests with RFC compliant cache support.
 - [gotql](https://github.com/khaosdoctor/gotql) - GraphQL request library built on [got](https://github.com/sindresorhus/got).
 - [global-agent](https://github.com/gajus/global-agent) - Global HTTP/HTTPS proxy agent that is configurable using environment variables.
+- [smoke](https://github.com/sinedied/smoke) - File-based HTTP mock server with recording abilities.
 
 ### Debugging / Profiling
 


### PR DESCRIPTION
Hi! 👋🏼

I created this PR to add `smoke` to the list of HTTP tools.
Smoke is a file-based HTTP mock server with recording abilities and more.

## What makes it different?
Most existing mock servers requires a lot of configuration to create mock files and make it work.

Smoke takes a different approach by allowing you to record mock files from a real server by acting like a proxy.
Creating a mock from scratch is also as easy as dropping JSON in a file and giving a name like: `get_api#hello.json` to produce an `/api/hello` GET endpoint.

It also requires no config, and can use its proxy abilities to do things like partial mocking, redirecting calls to an existing server while allowing partial overrides with mocks.

In a few words: it's an easy to use tool to stub your API backend, work offline, simulate errors or do backend-less tests, as you need.

Thanks!
