### PR TITLE
Add link to Netlify job description

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@
 
 ---
 
-A friend of mine (@ehmicky) is looking for a senior/expert Node.js backend engineer to join their fully remote, international, diverse (44% women and non-binary) and friendly team at Netlify. The job description is [here](https://boards.greenhouse.io/netlify/jobs/4832483002).
+A friend of mine [@ehmicky](https://github.com/ehmicky) is looking for a senior/expert Node.js backend engineer to join their fully remote, international, diverse (44% women and non-binary) and friendly team at Netlify. The job description is [here](https://boards.greenhouse.io/netlify/jobs/4832483002).
 
 This is not an ad. A friend of mine works on this team and I know Netlify is a good place to work. - Sindre
 ---

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,7 @@
 
 A friend of mine is looking for a senior/expert Node.js backend engineer to join their fully remote, international, diverse (44% women and non-binary) and friendly team at Netlify. The job description is [here](https://boards.greenhouse.io/netlify/jobs/4832483002).
 
+This is not an ad. A friend of mine works on this team and I know Netlify is a good place to work. - Sindre
 ---
 
 ## Contents

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@
 
 ---
 
-A friend of mine is looking for a senior/expert Node.js backend engineer to join their fully remote, international, diverse (44% women and non-binary) and friendly team at Netlify. The job description is [here](https://boards.greenhouse.io/netlify/jobs/4832483002).
+A friend of mine (@ehmicky) is looking for a senior/expert Node.js backend engineer to join their fully remote, international, diverse (44% women and non-binary) and friendly team at Netlify. The job description is [here](https://boards.greenhouse.io/netlify/jobs/4832483002).
 
 This is not an ad. A friend of mine works on this team and I know Netlify is a good place to work. - Sindre
 ---

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,6 @@
 
 A friend of mine [@ehmicky](https://github.com/ehmicky) is looking for a senior/expert Node.js backend engineer to join their fully remote, international, diverse (44% women and non-binary) and friendly team at Netlify. The job description is [here](https://boards.greenhouse.io/netlify/jobs/4832483002).
 
-This is not an ad. A friend of mine works on this team and I know Netlify is a good place to work. - Sindre
 ---
 
 ## Contents

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,12 @@
 	<br>
 </div>
 
+---
+
+Netlify is looking for a senior/expert Node.js backend engineer to join a fully remote, international, diverse (44% women and non-binary) and friendly team. The job description is [here](https://boards.greenhouse.io/netlify/jobs/4832483002).
+
+---
+
 ## Contents
 
 - [Packages](#packages)

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@
 
 ---
 
-Netlify is looking for a senior/expert Node.js backend engineer to join a fully remote, international, diverse (44% women and non-binary) and friendly team. The job description is [here](https://boards.greenhouse.io/netlify/jobs/4832483002).
+A friend of mine is looking for a senior/expert Node.js backend engineer to join their fully remote, international, diverse (44% women and non-binary) and friendly team at Netlify. The job description is [here](https://boards.greenhouse.io/netlify/jobs/4832483002).
 
 ---
 


### PR DESCRIPTION
As discussed with @sindresorhus, this is adding a link to a job description for a Node.js senior backend position at Netlify.