### PR TITLE
Add Booster Framework

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -350,6 +350,7 @@
 - [TypeGraphQL](https://github.com/19majkel94/type-graphql) - Modern framework for creating GraphQL APIs with TypeScript, using classes and decorators.
 - [Tinyhttp](https://github.com/talentlessguy/tinyhttp) - Modern and fast Express-like web framework.
 - [Marble.js](https://github.com/marblejs/marble) - Functional reactive framework for building server-side apps, based on TypeScript and RxJS.
+- [Booster Framework](https://github.com/boostercloud/booster) - Event-driven cloud framework. All infrastructure is inferred from code, and exposed as a GraphQL API (see also: https://booster.cloud).
 
 ### Documentation
 


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆

Adding Booster Framework. 

**Website:** https://booster.cloud
**Github:** https://github.com/boostercloud/booster (documentation under the `doc` folder)
**NPM package:** https://www.npmjs.com/package/@boostercloud/cli

Booster Framework is an event-driven cloud-native framework that makes you focus on business logic only. Then, you can hit `boost deploy -e <stage>` and a new stage will be deployed to a cloud provider of your choice:
- AWS
- Azure
- Google Cloud
- K8S
