### PR TITLE
Add pg-mem

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -598,6 +598,7 @@
 	- [database-js](https://github.com/mlaanderson/database-js) - Wrapper for multiple databases with a JDBC-like connection.
 	- [Mongo Seeding](https://github.com/pkosiec/mongo-seeding) - Populate MongoDB databases with JavaScript and JSON files.
 	- [@databases](https://github.com/ForbesLindesay/atdatabases) - Query PostgreSQL, MySQL and SQLite3 with plain SQL without risking SQL injection.
+	- [pg-mem](https://github.com/oguimbal/pg-mem) - In-Memory PostgreSQL instance for your tests.
 
 ### Testing
 

--- a/readme.md
+++ b/readme.md
@@ -598,7 +598,7 @@
 	- [database-js](https://github.com/mlaanderson/database-js) - Wrapper for multiple databases with a JDBC-like connection.
 	- [Mongo Seeding](https://github.com/pkosiec/mongo-seeding) - Populate MongoDB databases with JavaScript and JSON files.
 	- [@databases](https://github.com/ForbesLindesay/atdatabases) - Query PostgreSQL, MySQL and SQLite3 with plain SQL without risking SQL injection.
-	- [pg-mem](https://github.com/oguimbal/pg-mem) - In-Memory PostgreSQL instance for your tests.
+	- [pg-mem](https://github.com/oguimbal/pg-mem) - In-memory PostgreSQL instance for your tests.
 
 ### Testing
 


### PR DESCRIPTION
Hi !

Would you consider adding [pg-mem](https://github.com/oguimbal/pg-mem) to this list ?

It's a pure js in-memory postgres database emulator easing unit/integration testing.

It also implements [adapters](https://github.com/oguimbal/pg-mem/wiki/Libraries-adapters) which allow to wrap an in-memory db to some [awesome nodejs db libs](https://github.com/sindresorhus/awesome-nodejs#database).

👉 [Play with it here](https://oguimbal.github.io/pg-mem-playground/)

# Why is it worth it ?

When testing code that use a db, you usually have to choose between those options :
- Mock all your requests... this is quite painful,  doesnt work for end-to-end tests, and locks-down implementation details.
- Run a real clean instance of your db by running your tests in docker... this has a really high overhead, and is hard to setup.
- Fallback to in-memory sqlite if supported by your ORM... this wont work if you use db-specific features (like `@>` operator with postgres)
- Use a real database ... that's a bad idea, for various obvious reasons. You're gonna hate yourself.

`pg-mem` is another option, which:
- Is easier to setup
- Is faster: since it's pure JS, you dont have any network or booting overhead.
- Allows you to introspect your queries
- You can even inspect the parsed syntax trees of executed SQL, since [its parser is also open source](https://github.com/oguimbal/pgsql-ast-parser)

See [FAQ](https://github.com/oguimbal/pg-mem/wiki/FAQ) for details.