### PR TITLE
add MariaDB Database Driver

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -601,7 +601,6 @@
 	- [Redis](https://github.com/luin/ioredis) - Redis client.
 	- [LevelUP](https://github.com/Level/levelup) - LevelDB.
 	- [MySQL](https://github.com/mysqljs/mysql) - MySQL client.
-	- [MariaDB](https://github.com/mariadb-corporation/mariadb-connector-nodejs) - MariaDB client. Supports MariaDB and MySQL.
 	- [couchdb-nano](https://github.com/apache/couchdb-nano) - CouchDB client.
 	- [Aerospike](https://github.com/aerospike/aerospike-client-nodejs) - Aerospike client.
 	- [Couchbase](https://github.com/couchbase/couchnode) - Couchbase client.
@@ -630,6 +629,7 @@
 	- [Mongo Seeding](https://github.com/pkosiec/mongo-seeding) - Populate MongoDB databases with JavaScript and JSON files.
 	- [@databases](https://github.com/ForbesLindesay/atdatabases) - Query PostgreSQL, MySQL and SQLite3 with plain SQL without risking SQL injection.
 	- [pg-mem](https://github.com/oguimbal/pg-mem) - In-memory PostgreSQL instance for your tests.
+ 	- [MariaDB](https://github.com/mariadb-corporation/mariadb-connector-nodejs) - MariaDB client. Supports MariaDB and MySQL.
 
 ### Testing
 

--- a/readme.md
+++ b/readme.md
@@ -601,6 +601,7 @@
 	- [Redis](https://github.com/luin/ioredis) - Redis client.
 	- [LevelUP](https://github.com/Level/levelup) - LevelDB.
 	- [MySQL](https://github.com/mysqljs/mysql) - MySQL client.
+	- [MariaDB](https://github.com/mariadb-corporation/mariadb-connector-nodejs) - MariaDB client. Supports MariaDB and MySQL.
 	- [couchdb-nano](https://github.com/apache/couchdb-nano) - CouchDB client.
 	- [Aerospike](https://github.com/aerospike/aerospike-client-nodejs) - Aerospike client.
 	- [Couchbase](https://github.com/couchbase/couchnode) - Couchbase client.


### PR DESCRIPTION
add MariaDB Database Driver (for popular MySQL open-source fork)

Related Links:
https://mariadb.org/
https://en.wikipedia.org/wiki/MariaDB
https://mariadb.com/kb/en/about-mariadb-connector-nodejs/

snippet from ReadMe:

> 
> Non-blocking MariaDB and MySQL client for Node.js.
> MariaDB and MySQL client, 100% JavaScript, with TypeScript definition, with the Promise API.
> 
> While there are existing MySQL clients that work with MariaDB, (such as the mysql and mysql2 clients), the MariaDB Node.js Connector offers new functionality, like Insert Streaming, Pipelining, ed25519 plugin authentication while making no compromises on performance.


**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
