### PR TITLE
Include sonic < express > in documentation section 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -433,6 +433,7 @@
 - [Docco](https://github.com/jashkenas/docco) - Documentation generator which produces an HTML document that displays your comments intermingled with your code.
 - [JSDoc](https://github.com/jsdoc3/jsdoc) - API documentation generator similar to JavaDoc or PHPDoc.
 - [Docusaurus](https://github.com/facebook/docusaurus) - Documentation website generator that leverages React and Markdown, and comes with translation and versioning features.
+- [Sonic < express >](https://github.com/Tiemma/sonic-express) - Middleware providing type inference, params, query, request and response capturing on Swagger for Express driven APIs.
 
 ### Filesystem
 


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆

Link to the package: https://github.com/Tiemma/sonic-express


Reasons for including: It adds support for API documentation on the fly which is not common amongst the Express ecosystem.

It has some similar design considerations to [Flask RestX](https://github.com/python-restx/flask-restx) but due to Node's limitation in support for implicitly documenting APIs, this uses tests or gives the user the ability to generate as they work on the APIs themselves (self-documented at the end of the day). 

As far as requests hit the API, the middle ware would document them as they go and overwrite subsequent requests based on the status code and other param.

I currently built this and it is used at [Replex](https://replex.io) where I work and over the months, I have on-boarded users who've had similar problems and issued fixes and API updates and they use it too hassle free.

Looking to extend visibility for it as it works really well from the feedback I've gotten and ease of integration from external parties.

