### PR TITLE
Add NodeJS/Typescript Project Template 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -977,6 +977,7 @@
 - [Microsoft Node.js Guidelines](https://github.com/Microsoft/nodejs-guidelines) - Tips, tricks, and resources for working with Node.js on Microsoft platforms.
 - [Module Requests & Ideas](https://github.com/sindresorhus/module-requests) - Request a JavaScript module you wish existed or get ideas for modules.
 - [v8-perf](https://github.com/thlorenz/v8-perf) - Notes and resources related to V8 and thus Node.js performance.
+- [typescript-project-skeleton-esbuild-jest](https://github.com/permafrost-dev/typescript-project-skeleton-esbuild-jest) - Template for NodeJS projects based on the latest versions of TypeScript, ESBuild, ESLint, Prettier, and Jest.  Updated regularly.
 
 ## Related lists
 


### PR DESCRIPTION
This adds a modern [NodeJS Project Template](https://github.com/permafrost-dev/typescript-project-skeleton-esbuild-jest): A starter template for NodeJS projects using the latest versions of TypeScript, ESBuild, ESLint, Prettier, and Jest.  Updated on a regular basis.
