### PR TITLE
Validate that links are up (once a week)

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,20 +1,15 @@
 name: Links
-
 on:
   schedule:
     # Run at 00:00 UTC every Sunday
     - cron: '0 0 * * */7'
-
 env:
   FORCE_COLOR: 1
-
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
-
       - name: Validate that links are up
         uses: simeg/urlsup-action@v1.0.0
         with:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,21 @@
+name: Links
+
+on:
+  schedule:
+    # Run at 00:00 UTC every Sunday
+    - cron: '0 0 * * */7'
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Validate that links are up
+        uses: simeg/urlsup-action@v1.0.0
+        with:
+          args: readme.md --threads 10


### PR DESCRIPTION
Every Sunday at midnight this Github action will validate that all
http/https links responds with 200. If a link has been permanently
removed (or just moved) it can be removed/changed which leads to a
higher quality list.

This check is already in place in the mac-setup[0] repo and is working
well. It won't prevent any PRs from getting merged, and optionally a
badge can be added to the README to highlight the link status (see
mac-setup repo).

[0]: https://github.com/sb2nov/mac-setup/

---

Hi @sindresorhus! I'm curious what you think of my suggestion. I think this will increase the quality of this nice repo! 🙂 It will make commits like [this one](https://github.com/sindresorhus/awesome-nodejs/commit/041a511ee4ab86b2069a2071d1e89abdc38a040d) easier to create as the workflow will figure out what URLs are != 200.