### PR TITLE
Add Async Library

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -501,6 +501,7 @@
 	- [More…](https://github.com/sindresorhus/awesome-observables)
 - Streams
 	- [Highland.js](https://github.com/caolan/highland) - Manages synchronous and asynchronous code easily, using nothing more than standard JavaScript and Node-like Streams.
+	- [Async](https://github.com/caolan/async) - Async provides around 70 functions that include the usual 'functional' suspects (map, reduce, filter, each…) as well as some common patterns for asynchronous control flow (parallel, series, waterfall…). 
 
 ### Streams
 


### PR DESCRIPTION
https://github.com/caolan/async

a 50 million download weekly library. This is the goto library for organizing async work within an application. 

 I see highland listed (which is only 60k weekly downloads) which is by the same author, and may be a spiritual successor to Async, but the API is much more complicated  and has increased scope (and is also not widely use).

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
