### PR TITLE
#1239 - fixed broken links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -902,7 +902,7 @@
 - [Nodeschool](https://github.com/nodeschool) - Learn Node.js with interactive lessons.
 - [The Art of Node](https://github.com/maxogden/art-of-node/#the-art-of-node) - An introduction to Node.js.
 - [module-best-practices](https://github.com/mattdesl/module-best-practices) - Some good practices when writing new npm modules.
-- [The Node Way](https://thenodeway.io) - An entire philosophy of Node.js best practices and guiding principles exists for writing maintainable modules, scalable applications, and code that is actually pleasant to read.
+- [The Node Way](https://github.com/FredKSchott/the-node-way) - An entire philosophy of Node.js best practices and guiding principles exists for writing maintainable modules, scalable applications, and code that is actually pleasant to read.
 - [You Don't Know Node.js](https://github.com/azat-co/you-dont-know-node) - Introduction to Node.js core features and asynchronous JavaScript.
 - [Portable Node.js guide](https://github.com/ehmicky/cross-platform-node-guide) - Practical guide on how to write portable/cross-platform Node.js code.
 - [Build a real web app with no frameworks](https://frameworkless.js.org/course) - A set of video tutorials/livestreams to help you build and deploy a real, live web app using a handful of simple libraries and the core Node.js modules.
@@ -915,7 +915,7 @@
 
 ### Articles
 
-- [Error Handling in Node.js](https://www.joyent.com/node-js/production/design/errors)
+- [Error Handling in Node.js](https://sematext.com/blog/node-js-error-handling/)
 - [Teach Yourself Node.js in 10 Steps](https://ponyfoo.com/articles/teach-yourself-nodejs-in-10-steps)
 - [Mastering the filesystem in Node.js](https://medium.com/@yoshuawuyts/mastering-the-filesystem-in-node-js-4706b7cb0801)
 - [Semver: A Primer](https://nodesource.com/blog/semver-a-primer/)


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
Two broken links:
## 1) https://thenodeway.io/
![image](https://user-images.githubusercontent.com/114554280/236678961-dad144b4-5b1f-4fa7-a666-44812d421610.png)
## 2) https://www.joyent.com/node-js/production/design/errors
![image](https://user-images.githubusercontent.com/114554280/236679023-43d0c414-d27c-4e44-a463-b47040bf90fb.png)

I changed these links with these two:

### https://github.com/FredKSchott/the-node-way
### https://sematext.com/blog/node-js-error-handling/

If you want anything changed, please don't hesitate to ask!

### NOTE: the third link in #1239 (https://npmcompare.com/) is not broken:
![image](https://user-images.githubusercontent.com/114554280/236679177-48d5423d-03e9-4b26-b4bb-7e6715dd4c2d.png)

Fixes #1239
