### PR TITLE
Add sqlx-ts under Compile-time checked queries (new category)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -617,6 +617,8 @@
 	- [TypeORM](https://github.com/typeorm/typeorm) - ORM for PostgreSQL, MariaDB, MySQL, SQLite, and more.
 	- [MikroORM](https://github.com/mikro-orm/mikro-orm) - TypeScript ORM based on Data Mapper, Unit of Work and Identity Map patterns. Supports MongoDB, PostgreSQL, MySQL and SQLite.
 	- [Prisma](https://github.com/prisma/prisma) - Modern database access (ORM alternative). Auto-generated and type-safe query builder in TypeScript. Supports PostgreSQL, MySQL & SQLite.
+- Compile-time Checked Queries
+        - [sqlx-ts](https://github.com/JasonShin/sqlx-ts) - sqlx-ts is a CLI application featuring compile-time checked queries without a DSL and generates types against SQLs to keep your code type-safe
 - Query builder
 	- [Knex](https://github.com/knex/knex) - Query builder for PostgreSQL, MySQL and SQLite3, designed to be flexible, portable, and fun to use.
 - Other

--- a/readme.md
+++ b/readme.md
@@ -618,7 +618,7 @@
 	- [MikroORM](https://github.com/mikro-orm/mikro-orm) - TypeScript ORM based on Data Mapper, Unit of Work and Identity Map patterns. Supports MongoDB, PostgreSQL, MySQL and SQLite.
 	- [Prisma](https://github.com/prisma/prisma) - Modern database access (ORM alternative). Auto-generated and type-safe query builder in TypeScript. Supports PostgreSQL, MySQL & SQLite.
 - Compile-time Checked Queries
-        - [sqlx-ts](https://github.com/JasonShin/sqlx-ts) - sqlx-ts is a CLI application featuring compile-time checked queries without a DSL and generates types against SQLs to keep your code type-safe
+	- [sqlx-ts](https://github.com/JasonShin/sqlx-ts) - CLI tool featuring compile-time checked queries without a DSL and generates types against SQLs to keep your code type-safe.
 - Query builder
 	- [Knex](https://github.com/knex/knex) - Query builder for PostgreSQL, MySQL and SQLite3, designed to be flexible, portable, and fun to use.
 - Other

--- a/readme.md
+++ b/readme.md
@@ -617,7 +617,7 @@
 	- [TypeORM](https://github.com/typeorm/typeorm) - ORM for PostgreSQL, MariaDB, MySQL, SQLite, and more.
 	- [MikroORM](https://github.com/mikro-orm/mikro-orm) - TypeScript ORM based on Data Mapper, Unit of Work and Identity Map patterns. Supports MongoDB, PostgreSQL, MySQL and SQLite.
 	- [Prisma](https://github.com/prisma/prisma) - Modern database access (ORM alternative). Auto-generated and type-safe query builder in TypeScript. Supports PostgreSQL, MySQL & SQLite.
-- Compile-time Checked Queries
+- Compile-time checked queries
 	- [sqlx-ts](https://github.com/JasonShin/sqlx-ts) - CLI tool featuring compile-time checked queries without a DSL and generates types against SQLs to keep your code type-safe.
 - Query builder
 	- [Knex](https://github.com/knex/knex) - Query builder for PostgreSQL, MySQL and SQLite3, designed to be flexible, portable, and fun to use.


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆


Hi, I've recently worked on a project sqlx-ts

https://github.com/JasonShin/sqlx-ts

blog articles: https://functional.works-hub.com/learn/sqlx-ts-compile-time-checked-queries-with-dsl-in-typescript-9c47b

It is a tool that is featuring compile-time checked queries without a DSL and generates types against SQLs to keep your code type safe. It works nicely with node.js codebase as you can still use sqlx-ts to simply perform query validations only.

In the TS world, I firmly believe that it is a replacement of schemats listed under https://github.com/dzharii/awesome-typescript/blob/master/README.md#tools
-> This is because the project is unmaintained and sqlx-ts is written in Rust with all the modern capabilities