### PR TITLE
Add Hono web framework

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -393,7 +393,7 @@
 - [Marble.js](https://github.com/marblejs/marble) - Functional reactive framework for building server-side apps, based on TypeScript and RxJS.
 - [Lad](https://github.com/ladjs/lad) - Framework made by a former Express TC and Koa member that bundles web, API, job, and proxy servers.
 - [Ts.ED](https://github.com/tsedio/tsed) - Intituive TypeScript framework for building server-side apps on top of Express.js or Koa.js.
-- [Hono](https://github.com/honojs/hono) - Small, simple, and ultrafast web framework for the Edges. It works on any JavaScript runtime: Cloudflare Workers, Fastly Compute, Deno, Bun, Vercel, Netlify, AWS Lambda, Lambda@Edge, and Node.js.
+- [Hono](https://github.com/honojs/hono) - Small, simple, and ultrafast web framework for the Edges. It works on any JavaScript runtime.
 
 ### Documentation
 

--- a/readme.md
+++ b/readme.md
@@ -393,7 +393,7 @@
 - [Marble.js](https://github.com/marblejs/marble) - Functional reactive framework for building server-side apps, based on TypeScript and RxJS.
 - [Lad](https://github.com/ladjs/lad) - Framework made by a former Express TC and Koa member that bundles web, API, job, and proxy servers.
 - [Ts.ED](https://github.com/tsedio/tsed) - Intituive TypeScript framework for building server-side apps on top of Express.js or Koa.js.
-- [Hono](https://github.com/honojs/hono) - Small, simple, and ultrafast web framework for the Edges. It works on any JavaScript runtime.
+- [Hono](https://github.com/honojs/hono) - Small and fast web framework.
 
 ### Documentation
 

--- a/readme.md
+++ b/readme.md
@@ -392,7 +392,8 @@
 - [Tinyhttp](https://github.com/tinyhttp/tinyhttp) - Modern and fast Express-like web framework.
 - [Marble.js](https://github.com/marblejs/marble) - Functional reactive framework for building server-side apps, based on TypeScript and RxJS.
 - [Lad](https://github.com/ladjs/lad) - Framework made by a former Express TC and Koa member that bundles web, API, job, and proxy servers.
-- [Ts.ED](https://github.com/tsedio/tsed) - Intituive TypeScript framework for building server-side apps on top of Express.js or Koa.js. 
+- [Ts.ED](https://github.com/tsedio/tsed) - Intituive TypeScript framework for building server-side apps on top of Express.js or Koa.js.
+- [Hono](https://github.com/honojs/hono) - Small, simple, and ultrafast web framework for the Edges. It works on any JavaScript runtime: Cloudflare Workers, Fastly Compute, Deno, Bun, Vercel, Netlify, AWS Lambda, Lambda@Edge, and Node.js.
 
 ### Documentation
 
@@ -834,7 +835,7 @@
 - [npm](https://docs.npmjs.com/about-npm) - The default package manager.
 - [pnpm](https://pnpm.io) - Disk space efficient package manager.
 - [yarn](https://yarnpkg.com) - Alternative package manager.
-- [bun](https://bun.sh) - All-in-one toolkit for JavaScript and TypeScript apps. 
+- [bun](https://bun.sh) - All-in-one toolkit for JavaScript and TypeScript apps.
 
 ## Resources
 


### PR DESCRIPTION
Added Hono web framework


Github link: https://github.com/honojs/hono
Offical website: https://hono.dev/

Why to include:
Hone is new modern web framework which cab be used in multiple JS runtimes like Nodejs, Deno, Bun, Cloudflare workers. It is one of the fasted framework which is built on web Request and Response. 