### PR TITLE
feat: added bree to job queues

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -724,7 +724,7 @@
 - [sqs-consumer](https://github.com/bbc/sqs-consumer) - Build Amazon Simple Queue Service (SQS) based apps without the boilerplate.
 - [better-queue](https://github.com/diamondio/better-queue) - Simple and efficient job queue when you cannot use Redis.
 - [bullmq](https://github.com/taskforcesh/bullmq) - Persistent job and message queue.
-- [bree](https://github.com/breejs/bree) - Job task scheduler with worker threads, cron, Date, and human syntax support
+- [bree](https://github.com/breejs/bree) - Job task scheduler with worker threads, cron, Date, and human syntax support.
 
 ### Node.js management
 

--- a/readme.md
+++ b/readme.md
@@ -714,7 +714,6 @@
 
 ### Job queues
 
-- [bree](https://github.com/breejs/bree) - Job task scheduler with worker threads, cron, Date, and human syntax support
 - [bull](https://github.com/OptimalBits/bull) - Persistent job and message queue.
 - [agenda](https://github.com/agenda/agenda) - MongoDB-backed job scheduling.
 - [idoit](https://github.com/nodeca/idoit) - Redis-backed job queue engine with advanced job control.
@@ -725,6 +724,7 @@
 - [sqs-consumer](https://github.com/bbc/sqs-consumer) - Build Amazon Simple Queue Service (SQS) based apps without the boilerplate.
 - [better-queue](https://github.com/diamondio/better-queue) - Simple and efficient job queue when you cannot use Redis.
 - [bullmq](https://github.com/taskforcesh/bullmq) - Persistent job and message queue.
+- [bree](https://github.com/breejs/bree) - Job task scheduler with worker threads, cron, Date, and human syntax support
 
 ### Node.js management
 

--- a/readme.md
+++ b/readme.md
@@ -724,7 +724,7 @@
 - [sqs-consumer](https://github.com/bbc/sqs-consumer) - Build Amazon Simple Queue Service (SQS) based apps without the boilerplate.
 - [better-queue](https://github.com/diamondio/better-queue) - Simple and efficient job queue when you cannot use Redis.
 - [bullmq](https://github.com/taskforcesh/bullmq) - Persistent job and message queue.
-- [bree](https://github.com/breejs/bree) - Job task scheduler with worker threads, cron, Date, and human syntax support.
+- [bree](https://github.com/breejs/bree) - Job task scheduler with worker threads, cron, date, and human syntax support.
 
 ### Node.js management
 

--- a/readme.md
+++ b/readme.md
@@ -714,6 +714,7 @@
 
 ### Job queues
 
+- [bree](https://github.com/breejs/bree) - Job task scheduler with worker threads, cron, Date, and human syntax support
 - [bull](https://github.com/OptimalBits/bull) - Persistent job and message queue.
 - [agenda](https://github.com/agenda/agenda) - MongoDB-backed job scheduling.
 - [idoit](https://github.com/nodeca/idoit) - Redis-backed job queue engine with advanced job control.


### PR DESCRIPTION
Hi there 👋   We've added @breejs to the list of job queues.  We formerly maintained Agenda (which is listed) and currently use Bree in production for 500,000+ domain names in our email service @forwardemail.  We'd love to see Bree added to the list!  It has types, tests, spawned sandboxed processes, supports async/await, retries, throttling, concurrency, and cancelable jobs with graceful shutdown.  Additional docs are at <https://jobscheduler.net>.  Thank you! 🙏