### PR TITLE
Add Eicrud top the web framework list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -410,6 +410,7 @@
 - [Lad](https://github.com/ladjs/lad) - Framework made by a former Express TC and Koa member that bundles web, API, job, and proxy servers.
 - [Ts.ED](https://github.com/tsedio/tsed) - Intituive TypeScript framework for building server-side apps on top of Express.js or Koa.js.
 - [Hono](https://github.com/honojs/hono) - Small and fast web framework.
+- [Eicrud](https://github.com/honojs/hono) - Opinionated framework extending Nest with CRUD services, user management commands, and role-based access control.
 
 ### Documentation
 


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆

## Description

https://github.com/eicrud/eicrud

Eicrud is CRUD/Authorization framework extending NestJS. It bring an extra opinionated layer on top of Nest for doing CRUD and role-based access control. List of features includes:

CRUD services
Authentication & user management
Authorization
Commands
Validation/Transform
Database control
Client
Monolithic/Microservices

## Reasons to bypass the web framework rule  and why Eicrud is unique

Most framework listed are light and give basic tools to write you're own MVC logic.


