### PR TITLE
Add Eicrud to the web framework list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -410,6 +410,7 @@
 - [Lad](https://github.com/ladjs/lad) - Framework made by a former Express TC and Koa member that bundles web, API, job, and proxy servers.
 - [Ts.ED](https://github.com/tsedio/tsed) - Intituive TypeScript framework for building server-side apps on top of Express.js or Koa.js.
 - [Hono](https://github.com/honojs/hono) - Small and fast web framework.
+- [Eicrud](https://github.com/honojs/hono) - Opinionated framework extending Nest with CRUD services, user management commands, and role-based access control.
 
 ### Documentation
 


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆

## Description

https://github.com/eicrud/eicrud

Eicrud is a CRUD/Authorization framework extending NestJS. It bring an extra opinionated layer on top of Nest for doing CRUD and role-based access control. List of features includes:

CRUD services
Authentication & user management
Authorization
Commands
Validation/Transform
Database control
Client
Monolithic/Microservices

## Reasons to bypass the web framework rule and why Eicrud is unique

Most frameworks listed are lightweight and provide basic tools to write your own MVC logic.

In opposition Eicrud is heavily opinionated, you don't write your own controllers. Instead, you simply declare your data model (Entities or DTOs) and the controlling/routing logic is handled for you.

Additionally, it provides something that I couldn't find in other frameworks: an opinionated structure to prevent large projects from becoming too complex.
