### PR TITLE
fix a broken link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -858,7 +858,7 @@
 
 - [npms](https://npms.io) - Superb package search with deep analysis of package quality using a [myriad of metrics](https://npms.io/about).
 - [npm addict](https://npmaddict.com) - Your daily injection of npm packages.
-- [npmcompare.com](https://npmcompare.com) - Compare and discover npm packages.
+- [npm-compare.com](https://npm-compare.com) - Compare and discover npm packages.
 
 ### Articles
 


### PR DESCRIPTION
This PR aims to improve documentation by updating a broken link. The current link, npmcompare.com, is outdated and no longer maintained. I've replaced it with the active npm-compare.com.

Thank you for reviewing this update to ensure our resources remain accurate and helpful.

