### PR TITLE
Add auto-dep-install to Command Line Utilities section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -328,6 +328,7 @@
 - [terminal-size](https://github.com/sindresorhus/terminal-size) - Reliably get the terminal window size.
 - [Cliffy](https://github.com/drew-y/cliffy) - Framework for interactive CLIs.
 - [zx](https://github.com/google/zx) - Write shell scripts JavaScript.
+- [auto-dep-install](https://github.com/sarthakNITT/auto-dep-install) - Automate installation of missing dependencies in JavaScript/TypeScript projects based on import analysis.
 
 ### Build tools
 


### PR DESCRIPTION
 auto-dep-install is a CLI tool that helps automate dependency installation and cleanup in JavaScript/TypeScript projects.

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
