### PR TITLE
add YAMLResume

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,6 +198,7 @@
 - [taskbook](https://github.com/klaussinani/taskbook) - Tasks, boards & notes for the command-line habitat.
 - [discharge](https://github.com/brandonweiss/discharge) - Easily deploy static websites to Amazon S3.
 - [npkill](https://github.com/voidcosmos/npkill) - Easily find and remove old and heavy node_modules folders.
+- [yamlresume](https://github.com/yamlresume/yamlresume) - Create and version control resumes as code in yaml.
 
 ### Functional programming
 


### PR DESCRIPTION
[YAMLResume](https://yamlresume.dev) is a CLI tool and node.js lib that allows people to create and version control resumes as code in YAML.

- repo: https://github.com/yamlresume/yamlresume
- docs: https://yamlresume.dev/docs
- npm: https://www.npmjs.com/package/yamlresume
- docker: https://hub.docker.com/r/yamlresume/yamlresume

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
