### PR TITLE
Add Vitest to testing frameworks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -602,7 +602,7 @@
 - [Nightwatch](https://github.com/nightwatchjs/nightwatch) - Automated UI testing framework based on Selenium WebDriver.
 - [WebdriverIO](https://github.com/webdriverio/webdriverio) - Automated testing based on the WebDriver protocol.
 - [Jest](https://github.com/facebook/jest) - Painless JavaScript testing.
-- [Vitest](https://github.com/vitest-dev/vitest) - Blazing fast unit test framework powered by Vite.
+- [Vitest](https://github.com/vitest-dev/vitest) - Fast unit test framework powered by Vite.
 - [TestCafe](https://github.com/DevExpress/testcafe) - Automated browser testing.
 - [abstruse](https://github.com/bleenco/abstruse) - Continuous Integration server.
 - [CodeceptJS](https://github.com/codeceptjs/CodeceptJS) - End-to-end testing.

--- a/readme.md
+++ b/readme.md
@@ -602,6 +602,7 @@
 - [Nightwatch](https://github.com/nightwatchjs/nightwatch) - Automated UI testing framework based on Selenium WebDriver.
 - [WebdriverIO](https://github.com/webdriverio/webdriverio) - Automated testing based on the WebDriver protocol.
 - [Jest](https://github.com/facebook/jest) - Painless JavaScript testing.
+- [Vitest](https://github.com/vitest-dev/vitest) - Blazing fast unit test framework powered by Vite.
 - [TestCafe](https://github.com/DevExpress/testcafe) - Automated browser testing.
 - [abstruse](https://github.com/bleenco/abstruse) - Continuous Integration server.
 - [CodeceptJS](https://github.com/codeceptjs/CodeceptJS) - End-to-end testing.


### PR DESCRIPTION
## Description
Adds [Vitest](https://github.com/vitest-dev/vitest) to the Testing section.

## Why Vitest should be included
Vitest has become a popular modern testing framework in the Node.js ecosystem with:
- **700k+ weekly downloads** on npm
- **32k+ stars** on GitHub  
- Native ESM and TypeScript support
- Jest-compatible APIs for easy migration
- Blazing fast performance powered by Vite
- Built-in component testing for Vue/React
- Parallel test execution and snapshot testing

## Placement
Added alphabetically after Jest in the Testing section, as it's often considered a modern alternative to Jest.

Closes any related issues about missing Vitest in the testing tools list.