### PR TITLE
feat: added Forward Email to email list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -664,7 +664,7 @@
 - [emailjs](https://github.com/eleith/emailjs) - Send text/HTML emails with attachments to any SMTP server.
 - [email-templates](https://github.com/forwardemail/email-templates) - Create, preview, and send custom email templates.
 - [MJML](https://github.com/mjmlio/mjml) - Markup language designed to reduce the pain of creating responsive emails.
-- [Forward Email](https://github.com/forwardemail/forwardemail.net) - 100% open-source & self-hostable email service built with JavaScript (IMAP/POP3/SMTP/CalDAV/CardDAV)
+- [Forward Email](https://github.com/forwardemail/forwardemail.net) - Open-source and self-hostable email service.
 
 ### Job queues
 


### PR DESCRIPTION
Forward Email is self-hostable with a Docker image as well, see guides below!

<https://forwardemail.net/en/self-hosted>

<https://forwardemail.net/en/blog/docs/self-hosted-solution>

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
