### PR TITLE
Add docmd to Documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -379,7 +379,7 @@
 ### Documentation
 
 - [Docco](https://github.com/jashkenas/docco) - Documentation generator which produces an HTML document that displays your comments intermingled with your code.
-- [docmd](https://github.com/mgks/docmd) - Markdown to HTML documentation generator with custom containers and offline search.
+- [docmd](https://github.com/docmd-io/docmd) - Markdown to HTML documentation generator with custom containers and offline search.
 - [documentation.js](https://github.com/documentationjs/documentation) - API documentation generator with support for ES2015+ and flow annotation.
 - [Docusaurus](https://github.com/facebook/docusaurus) - Documentation website generator that leverages React and Markdown, and comes with translation and versioning features.
 - [JSDoc](https://github.com/jsdoc/jsdoc) - API documentation generator similar to JavaDoc or PHPDoc.

--- a/readme.md
+++ b/readme.md
@@ -378,10 +378,11 @@
 
 ### Documentation
 
-- [documentation.js](https://github.com/documentationjs/documentation) - API documentation generator with support for ES2015+ and flow annotation.
 - [Docco](https://github.com/jashkenas/docco) - Documentation generator which produces an HTML document that displays your comments intermingled with your code.
-- [JSDoc](https://github.com/jsdoc/jsdoc) - API documentation generator similar to JavaDoc or PHPDoc.
+- [docmd](https://github.com/mgks/docmd) - Markdown to HTML documentation generator with custom containers and offline search.
+- [documentation.js](https://github.com/documentationjs/documentation) - API documentation generator with support for ES2015+ and flow annotation.
 - [Docusaurus](https://github.com/facebook/docusaurus) - Documentation website generator that leverages React and Markdown, and comes with translation and versioning features.
+- [JSDoc](https://github.com/jsdoc/jsdoc) - API documentation generator similar to JavaDoc or PHPDoc.
 
 ### Filesystem
 


### PR DESCRIPTION
### Description
Adds docmd to the Documentation category.

### Why docmd should be included
docmd is a zero-configuration tool that generates static documentation sites from Markdown. It distinguishes itself with built-in offline search and custom containers, offering a simpler alternative to React-based generators.

It meets the requirements:
- [x] Repo is >30 days old (6 months).
- [x] Repo has >100 stars (500+ stars).
- [x] Tested and documented.

### Placement
Added alphabetically between Docco and documentation.js in the "Documentation" section.

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆