### PR TITLE
Add pdf-encrypt-lite to Security

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -648,6 +648,7 @@
 - [rate-limiter-flexible](https://github.com/animir/node-rate-limiter-flexible) - Brute-force and DDoS attack protection.
 - [crypto-hash](https://github.com/sindresorhus/crypto-hash) - Async non-blocking hashing.
 - [jose-simple](https://github.com/davesag/jose-simple) - Encryption and decryption of data using the JOSE (JSON Object Signing and Encryption) standard.
+- [pdf-encrypt-lite](https://github.com/pdfsmaller/pdf-encrypt-lite) - Ultra-lightweight (7KB) PDF encryption with RC4 128-bit. Works in edge runtimes.
 
 ### Benchmarking
 


### PR DESCRIPTION
## What is this package?

[pdf-encrypt-lite](https://www.npmjs.com/package/@pdfsmaller/pdf-encrypt-lite) is an ultra-lightweight (7KB) PDF encryption library that implements real RC4 128-bit encryption per the PDF specification.

## Why should it be included?

- **Solves a real problem**: Existing solutions (node-forge at 1.7MB, crypto-js at 234KB) are too large for edge runtimes
- **Battle-tested**: Powers [PDFSmaller.com](https://pdfsmaller.com)'s Protect PDF tool
- **Edge-ready**: Works in Cloudflare Workers, Vercel Edge, Deno Deploy (within 1MB limits)
- **Zero dependencies**: Only requires pdf-lib as peer dependency
- **Standards compliant**: Implements PDF Security Handler Algorithm 2 & 3

## Checklist

- [ ] I have read the [contribution guidelines](contributing.md)
- [x] This package is useful for Node.js developers
- [x] This package is not a duplicate

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/sindresorhus/awesome-nodejs/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
