### PR TITLE
Add Heroshot to Command-line apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -185,6 +185,7 @@
 - [trash](https://github.com/sindresorhus/trash) - Safer alternative to `rm`.
 - [speed-test](https://github.com/sindresorhus/speed-test) - Test your internet connection speed and ping.
 - [pageres](https://github.com/sindresorhus/pageres) - Capture website screenshots.
+- [Heroshot](https://github.com/omachala/heroshot) - Automate documentation screenshots with config-based workflows.
 - [cpy](https://github.com/sindresorhus/cpy) - Copy files.
 - [vtop](https://github.com/MrRio/vtop) - More better top, with nice charts.
 - [empty-trash](https://github.com/sindresorhus/empty-trash) - Empty the trash.


### PR DESCRIPTION
Hi! I'd like to add [Heroshot](https://github.com/omachala/heroshot) to the Command-line apps section, alongside pageres.

**Heroshot** is a CLI tool for automating documentation screenshots with:
- Config-based workflows (define once, update forever)
- Visual element picker in the browser
- Theme-aware captures (light/dark mode)
- Framework integrations (VitePress, Docusaurus, MkDocs)

Built on Playwright, it's particularly useful for maintaining up-to-date screenshots in documentation sites.

Thank you for maintaining this incredible resource!