### PR TITLE
Add soundcloud-api-ts to HTTP section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -249,6 +249,7 @@
 - [global-agent](https://github.com/gajus/global-agent) - Global HTTP/HTTPS proxy agent that is configurable using environment variables.
 - [smoke](https://github.com/sinedied/smoke) - File-based HTTP mock server with recording abilities.
 - [purest](https://github.com/simov/purest) - REST client.
+- [soundcloud-api-ts](https://github.com/twin-paws/soundcloud-api-ts) - Zero-dependency SoundCloud API client with OAuth 2.1, PKCE, typed errors, automatic retry, and CLI.
 
 ### Debugging / Profiling
 


### PR DESCRIPTION
Adds [soundcloud-api-ts](https://github.com/twin-paws/soundcloud-api-ts) — a zero-dependency, fully-typed TypeScript client for the SoundCloud API.

- **0 dependencies**, 4.5 KB min+gzip, native `fetch` (Node 20+)
- OAuth 2.1 + PKCE, automatic token refresh, exponential backoff on 429/5xx
- Typed errors (`SoundCloudError`), async pagination helpers
- Interactive CLI (`sc-cli`)
- 262 tests, 100% line/function coverage
- Provenance-signed via npm Trusted Publishing
- [npm](https://www.npmjs.com/package/soundcloud-api-ts) · [TypeDoc](https://twin-paws.github.io/soundcloud-api-ts/)

Added to the **HTTP** section as a REST API client.