### PR TITLE
Add temporal-parser to Date section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -500,6 +500,7 @@
 - [dateformat](https://github.com/felixge/node-dateformat) - Date formatting.
 - [tz-format](https://github.com/samverschueren/tz-format) - Format a date with timezone: `2015-11-30T10:40:35+01:00`.
 - [cctz](https://github.com/floatdrop/node-cctz) - Fast parsing, formatting, and timezone conversion for dates.
+- [temporal-parser](https://github.com/taskade/temporal-parser) - Lexer and parser for ISO 8601, RFC 3339, and IXDTF temporal expressions.
 
 ### URL
 


### PR DESCRIPTION
## Add temporal-parser

Adds [temporal-parser](https://github.com/taskade/temporal-parser) to the **Date** section.

### About

A lexer and parser for ISO 8601, RFC 3339, and IXDTF temporal expressions, built with compiler design principles (tokenizer + recursive descent parser).

- **GitHub:** https://github.com/taskade/temporal-parser
- **npm:** [@taskade/temporal-parser](https://www.npmjs.com/package/@taskade/temporal-parser)
- **License:** MIT
- **Zero dependencies**

Handles the full ISO 8601 spec including durations, intervals, recurring expressions, time zones, UTC offsets, and IXDTF calendar annotations.