### PR TITLE
Add Manifest to Debugging / Profiling

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -266,6 +266,7 @@
 - [swagger-stats](https://github.com/slanatech/swagger-stats) - Trace API calls and monitor API performance, health, and usage metrics.
 - [NiM](https://github.com/june07/nim) - Manages DevTools debugging workflow.
 - [dats](https://github.com/immobiliare/dats) - Minimalistic and zero-dependencies [StatsD](https://github.com/statsd/statsd) client.
+- [Manifest](https://github.com/mnfst/manifest) - Real-time cost observability for AI agents with token tracking, model usage metrics, and OTLP-native telemetry.
 
 ### Logging
 


### PR DESCRIPTION
## Summary

- Adds [Manifest](https://github.com/mnfst/manifest) to the **Debugging / Profiling** section
- Manifest is an open-source real-time cost observability platform for AI agents, built with Node.js (NestJS)
- It tracks tokens, costs, messages, and model usage with self-hostable, privacy-focused, OTLP-native telemetry
- Website: https://manifest.build
- License: MIT