### PR TITLE
superdiff

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,7 @@
 
 - [Official](#official)
 - [Packages](#packages)
+	- [Diff](#diff)
 	- [Mad science](#mad-science)
 	- [Command-line apps](#command-line-apps)
 	- [Functional programming](#functional-programming)
@@ -153,6 +154,10 @@
 - [Repository](https://github.com/nodejs/node)
 
 ## Packages
+
+### Diff
+
+- [superdiff](https://github.com/DoneDeal0/superdiff) - Rich diff for arrays, objects, texts and coordinates. Supports stream and file inputs for handling large datasets efficiently, zero dependencies, top-tier performance.
 
 ### Mad science
 


### PR DESCRIPTION
I propose to add a `Diff` category.

The library I suggest is [Superdiff](https://github.com/DoneDeal0/superdiff). 

## What is it?
**Superdiff** provides a rich and readable diff for **arrays**, **objects**, **texts** and **coordinates**. It supports **stream** and file inputs for handling large datasets efficiently, is battle-tested, has zero dependencies, and offers a **top-tier performance**. 
 
Github stars: 1.1K

## Why it's interesting

This is a unified diff library. The benchmarks show that Superdiff consistently outperforms or matches the fastest diff libraries. It also scales linearly, even with deeply nested data.


