### PR TITLE
Add PageGuard - Free website health scanner with AI reports

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -636,6 +636,7 @@
 - [CodeceptJS](https://github.com/codeceptjs/CodeceptJS) - End-to-end testing.
 - [Puppeteer](https://github.com/puppeteer/puppeteer) - Headless Chrome.
 - [Playwright](https://github.com/microsoft/playwright) - Headless Chromium, WebKit, and Firefox with a single API.
+- [PageGuard](https://pageguard.qiudeqiu.workers.dev) - Free website health scanner with SEO, performance, accessibility, and best practices audits powered by AI.
 - [nve](https://github.com/ehmicky/nve) - Run any command on multiple versions of Node.js locally.
 - [axe-core](https://github.com/dequelabs/axe-core) - Accessibility engine for automated Web UI testing.
 - [testcontainers-node](https://github.com/testcontainers/testcontainers-node) - Provides lightweight, throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container.


### PR DESCRIPTION
Add PageGuard to the Testing section.

PageGuard is a free, open-source website health scanner that provides:
- 🔍 SEO analysis
- ⚡ Performance scoring (via Google PageSpeed Insights API)
- ♿ Accessibility checks  
- ✅ Best practices audit
- 🤖 AI-powered improvement reports

Project: https://pageguard.qiudeqiu.workers.dev
GitHub: https://github.com/sleepyxpad-jpg/pageguard

Fits naturally in the Testing section as an automated web quality and performance testing tool.