### PR TITLE
Add releaserun - dependency EOL and CVE scanner

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -225,6 +225,7 @@
 - [taskbook](https://github.com/klaussinani/taskbook) - Tasks, boards & notes for the command-line habitat.
 - [discharge](https://github.com/brandonweiss/discharge) - Easily deploy static websites to Amazon S3.
 - [npkill](https://github.com/voidcosmos/npkill) - Easily find and remove old and heavy node_modules folders.
+- [releaserun](https://github.com/Releaserun/releaserun-cli) - Scan project dependencies for end-of-life runtimes, known CVEs, and version health grades.
 
 ### Functional programming
 


### PR DESCRIPTION
Adds [releaserun](https://github.com/Releaserun/releaserun-cli) to the Command-line apps section.

`releaserun` scans your project's dependency files (package.json, requirements.txt, go.mod, Gemfile, Cargo.toml, pom.xml) and reports which technologies are approaching end-of-life, have known CVEs, or need upgrading. It gives each technology a health grade (A-F) based on live data from endoflife.date.

- Published on npm: `npx releaserun check`
- Supports 9 file types and 300+ products
- CI-friendly: `npx releaserun ci --fail-on D`
- Also generates README badges: `npx releaserun badges`