### PR TITLE
Add pg-safe-migrate to Database > Other section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -606,6 +606,7 @@
 	- [Finale](https://github.com/tommybananas/finale) - RESTful endpoint generator for your Sequelize models.
 	- [database-js](https://github.com/mlaanderson/database-js) - Wrapper for multiple databases with a JDBC-like connection.
 	- [Mongo Seeding](https://github.com/pkosiec/mongo-seeding) - Populate MongoDB databases with JavaScript and JSON files.
+	- [pg-safe-migrate](https://github.com/defnotwig/pg-safe-migrate) - Safety-first PostgreSQL migration engine with advisory locks, drift detection, and lint rules.
 	- [@databases](https://github.com/ForbesLindesay/atdatabases) - Query PostgreSQL, MySQL and SQLite3 with plain SQL without risking SQL injection.
 	- [pg-mem](https://github.com/oguimbal/pg-mem) - In-memory PostgreSQL instance for your tests.
 


### PR DESCRIPTION
Adding [pg-safe-migrate](https://github.com/defnotwig/pg-safe-migrate) - a safety-first PostgreSQL migration engine for Node.js with advisory locks, drift detection, 10 lint rules, CLI, and GitHub Action. Published on npm, 153 tests, strict TypeScript, MIT licensed.