### PR TITLE
Add context-engine - context engine for AI agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -171,6 +171,7 @@
 - [YodaOS](https://github.com/yodaos-project/yodaos) - AI operating system.
 - [Brain.js](https://github.com/BrainJS/brain.js) - Machine-learning framework.
 - [Pipcook](https://github.com/alibaba/pipcook) - Front-end algorithm framework to create a machine learning pipeline.
+- [context-engine](https://github.com/Quinnod345/context-engine) - Lightweight context engine for AI agents with event ingestion, semantic context building, and natural language querying.
 - [Cytoscape.js](https://github.com/cytoscape/cytoscape.js) - Graph theory (a.k.a. network) modeling and analysis.
 - [js-git](https://github.com/creationix/js-git) - JavaScript implementation of Git.
 - [xlsx](https://github.com/SheetJS/sheetjs) - Pure JS Excel spreadsheet reader and writer.


### PR DESCRIPTION
## Description

Add [context-engine](https://github.com/Quinnod345/context-engine) to the Mad science section, alongside other AI/ML entries (Brain.js, Pipcook, YodaOS).

**context-engine** is a lightweight context engine for AI agents. It supports event ingestion, semantic context building, and natural language querying. Zero config default with SQLite + local TF-IDF embeddings.

- **npm:** [`context-engine-ai`](https://www.npmjs.com/package/context-engine-ai)
- **GitHub:** [Quinnod345/context-engine](https://github.com/Quinnod345/context-engine)