### PR TITLE
Add oss-maintenance-log to Miscellaneous section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -815,6 +815,7 @@
 - [editly](https://github.com/mifi/editly) - Declarative video editing API.
 - [wild-wild-path](https://github.com/ehmicky/wild-wild-path) - Object property paths with wildcards and regexes.
 - [uint8array-extras](https://github.com/sindresorhus/uint8array-extras) - Useful utilities for working with Uint8Array and Buffer.
+- [oss-maintenance-log](https://github.com/dusan-maintains/oss-maintenance-log) - Automated public evidence log for OSS maintenance. Tracks PR SLA, npm health, and repo metrics. Self-updates every 6h via GitHub Actions.
 
 ## Package Manager
 


### PR DESCRIPTION
Adds [oss-maintenance-log](https://github.com/dusan-maintains/oss-maintenance-log) — an automated public evidence log for OSS maintenance work.

It tracks PR SLA, npm download health, and repo metrics across abandoned-but-critical packages, committing machine-readable JSON + Markdown snapshots every 6 hours via GitHub Actions. Zero manual updates.

Currently tracking packages with a combined **1.7M npm downloads/week** including `rrule`, `python-shell`, `jquery-modal`, and others.

- MIT licensed
- Reusable as a template repo
- Live dashboard: https://dusan-maintains.github.io/oss-maintenance-log