### PR TITLE
Add kbot to Command-line apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -225,6 +225,7 @@
 - [taskbook](https://github.com/klaussinani/taskbook) - Tasks, boards & notes for the command-line habitat.
 - [discharge](https://github.com/brandonweiss/discharge) - Easily deploy static websites to Amazon S3.
 - [npkill](https://github.com/voidcosmos/npkill) - Easily find and remove old and heavy node_modules folders.
+- [kbot](https://github.com/isaacsight/kernel) - AI agent for the terminal with 39 specialists, 167 tools, and self-evolution.
 
 ### Functional programming
 


### PR DESCRIPTION
Adds [kbot](https://github.com/isaacsight/kernel) to the Command-line apps section.

kbot is an open-source terminal AI agent built in TypeScript/Node.js:
- 39 specialist agents auto-routed by intent
- 167 built-in tools (file ops, git, GitHub, web search, browser, notebooks, sandbox)
- 19 AI providers including local runtimes (Ollama, LM Studio)
- Self-evolution engine that improves its own source code
- MCP server for IDE integration

- npm: `npm install -g @kernel.chat/kbot`
- GitHub: https://github.com/isaacsight/kernel
- MIT licensed, TypeScript, Node.js 20+