### PR TITLE
Add LobsterMail to Email section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -678,6 +678,7 @@
 - [email-templates](https://github.com/forwardemail/email-templates) - Create, preview, and send custom email templates.
 - [MJML](https://github.com/mjmlio/mjml) - Markup language designed to reduce the pain of creating responsive emails.
 - [Forward Email](https://github.com/forwardemail/forwardemail.net) - Open-source and self-hostable email service.
+- [LobsterMail](https://lobstermail.ai/) - Email infrastructure for AI agents — agents self-provision inboxes with no human signup or API keys.
 
 ### Job queues
 


### PR DESCRIPTION
Added [LobsterMail](https://lobstermail.ai/) to the Email section.

Email infrastructure for AI agents — agents self-provision inboxes with no human signup or API keys. Node.js SDK available via `npm install lobstermail`.